### PR TITLE
Add draggable arc center handles

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -6,7 +6,7 @@ from PySide6.QtWidgets import QGraphicsScene, QGraphicsView, QMainWindow, QDockW
 
 from geometry import arc_geom_points, rounded_rect_points, cubic_spline_closed
 from scipy.interpolate import CubicSpline
-from points import GroupOfPoints, FreePoint
+from points import GroupOfPoints, FreePoint, ArcCenterHandle
 from inspector import InspectorWidget
 
 
@@ -34,11 +34,49 @@ class MainWindow(QMainWindow):
         self.addDockWidget(Qt.RightDockWidgetArea, dock)
         self._marker_states = None
         self.redraw_all()
+        self._init_center_handles()
         self._apply_transform()
 
     def update_free_points_radius(self):
         for fp in self.free_points:
             fp.update_radius()
+        if hasattr(self, "center_handles"):
+            for h in self.center_handles:
+                r = self.point_radius
+                h.setRect(-r, -r, 2 * r, 2 * r)
+
+    def _init_center_handles(self):
+        """Create movable handles for arc centers."""
+        self.center_handles = []
+        for i in range(4):
+            h = ArcCenterHandle(self, i)
+            self.scene.addItem(h)
+            self.center_handles.append(h)
+        self._update_center_handle_positions()
+
+    def _update_center_handle_positions(self):
+        """Position center handles based on current parameters."""
+        a2, b2, R = self.a / 2, self.b / 2, self.R
+        positions = [
+            QPointF(-a2 + R, b2 - R),
+            QPointF(-a2 + R, -b2 + R),
+            QPointF(a2 - R, -b2 + R),
+            QPointF(a2 - R, b2 - R),
+        ]
+        for h, pos in zip(self.center_handles, positions):
+            h.setPos(pos)
+
+    def center_handle_moved(self, idx, pos):
+        """Handle movement of arc center handles."""
+        x = pos.x()
+        y = pos.y()
+        self.a = 2 * (abs(x) + self.R)
+        self.b = 2 * (abs(y) + self.R)
+        self._update_center_handle_positions()
+        self.redraw_all(preserve_markers=True)
+        # update inspector spin boxes
+        self._inspector.a.setValue(self.a)
+        self._inspector.b.setValue(self.b)
 
     def eventFilter(self, obj, event):
         from PySide6.QtGui import QMouseEvent
@@ -192,6 +230,8 @@ class MainWindow(QMainWindow):
         self._draw_background(contour)
         self._draw_contour(contour)
         self._draw_spline()
+        if hasattr(self, "center_handles"):
+            self._update_center_handle_positions()
 
     def get_all_marker_positions(self):
         contour = self.get_contour()

--- a/points.py
+++ b/points.py
@@ -104,3 +104,22 @@ class FreePoint(QGraphicsEllipseItem):
             self.main_window._draw_spline()
             return QPointF(*contour[idx])
         return super().itemChange(change, value)
+
+
+class ArcCenterHandle(QGraphicsEllipseItem):
+    """Movable handle for arc centers."""
+    def __init__(self, main_window, index):
+        self.main_window = main_window
+        self.index = index
+        r = main_window.point_radius
+        super().__init__(-r, -r, 2 * r, 2 * r)
+        self.setBrush(QBrush(QColor(200, 50, 50)))
+        self.setPen(QPen(Qt.black, 1))
+        self.setZValue(5)
+        self.setFlag(QGraphicsEllipseItem.ItemIsMovable, True)
+        self.setFlag(QGraphicsEllipseItem.ItemSendsScenePositionChanges, True)
+
+    def itemChange(self, change, value):
+        if change == QGraphicsEllipseItem.ItemPositionChange:
+            self.main_window.center_handle_moved(self.index, value)
+        return super().itemChange(change, value)


### PR DESCRIPTION
## Summary
- allow interactive control of arc centers by dragging new handles
- update inspector values when handles move

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_686cd5682c7c8327bd79b19d1d82f1dc