### PR TITLE
Fix crash when redrawing scene

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -202,6 +202,9 @@ class MainWindow(QMainWindow):
         self.scene.clear()
         self.spline_path = None
         self.groups.clear()
+        if hasattr(self, "center_handles"):
+            # recreate handles because scene.clear() deletes items
+            self._init_center_handles()
 
         offsets = [5, 15]
         col = dict(center=QColor(255, 255, 255), near=QColor(0, 120, 255), far=QColor(0, 200, 80))


### PR DESCRIPTION
## Summary
- recreate arc center handles after clearing the scene

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cd74efa3083278f493a30d69c6c36