### PR TITLE
Add movable circle centers

### DIFF
--- a/geometry.py
+++ b/geometry.py
@@ -3,6 +3,17 @@ import numpy as np
 from scipy.interpolate import CubicSpline
 
 
+def arc_geom_points_from_centers(centers, R):
+    """Return (center, start, end) tuples for each arc using explicit centers."""
+    c0, c1, c2, c3 = centers
+    return [
+        (c0, (c0[0], c0[1] + R), (c0[0] - R, c0[1])),
+        (c1, (c1[0] - R, c1[1]), (c1[0], c1[1] - R)),
+        (c2, (c2[0], c2[1] - R), (c2[0] + R, c2[1])),
+        (c3, (c3[0] + R, c3[1]), (c3[0], c3[1] + R)),
+    ]
+
+
 def arc_geom_points(a, b, R):
     """Return (center, start, end) tuples for each arc."""
     a2, b2 = a / 2, b / 2
@@ -45,6 +56,40 @@ def rounded_rect_points(a, b, R, *, step=5.0, n_arc=180, n_line=200):
         arc(a2 - R, b2 - R, 0.0, math.pi / 2),
         line([a2 - R, b2], [-a2 + R, b2]),
     ])
+    seg = np.linalg.norm(np.diff(dense, axis=0, append=dense[:1]), axis=1)
+    s = np.concatenate(([0.0], np.cumsum(seg[:-1])))
+    total = s[-1] + seg[-1]
+    m = max(4, int(total / step))
+    su = np.linspace(0.0, total, m, endpoint=False)
+    x = np.interp(su, s, dense[:, 0])
+    y = np.interp(su, s, dense[:, 1])
+    return np.column_stack((x, y))
+
+
+def rounded_rect_points_from_centers(centers, R, *, step=5.0, n_arc=180, n_line=200):
+    """Return contour points for a rounded shape defined by centers."""
+
+    def arc(xc, yc, ang0, ang1):
+        t = np.linspace(ang0, ang1, n_arc, endpoint=False)
+        return np.column_stack((xc + R * np.cos(t), yc + R * np.sin(t)))
+
+    def line(p0, p1):
+        p0, p1 = map(np.asarray, (p0, p1))
+        t = np.linspace(0, 1, n_line, endpoint=False)[:, None]
+        return p0 + t * (p1 - p0)
+
+    c0, c1, c2, c3 = centers
+    dense = np.vstack([
+        arc(c0[0], c0[1], math.pi / 2, math.pi),
+        line([c0[0] - R, c0[1]], [c1[0] - R, c1[1]]),
+        arc(c1[0], c1[1], math.pi, 3 * math.pi / 2),
+        line([c1[0], c1[1] - R], [c2[0], c2[1] - R]),
+        arc(c2[0], c2[1], 3 * math.pi / 2, 2 * math.pi),
+        line([c2[0] + R, c2[1]], [c3[0] + R, c3[1]]),
+        arc(c3[0], c3[1], 0.0, math.pi / 2),
+        line([c3[0], c3[1] + R], [c0[0], c0[1] + R]),
+    ])
+
     seg = np.linalg.norm(np.diff(dense, axis=0, append=dense[:1]), axis=1)
     s = np.concatenate(([0.0], np.cumsum(seg[:-1])))
     total = s[-1] + seg[-1]

--- a/inspector.py
+++ b/inspector.py
@@ -53,16 +53,19 @@ class InspectorWidget(QWidget):
 
     def _change_a(self, v):
         self.main_window.a = v
+        self.main_window._reset_circle_centers()
         self.main_window.redraw_all(preserve_markers=True)
         self.update_error()
 
     def _change_b(self, v):
         self.main_window.b = v
+        self.main_window._reset_circle_centers()
         self.main_window.redraw_all(preserve_markers=True)
         self.update_error()
 
     def _change_R(self, v):
         self.main_window.R = v
+        self.main_window._reset_circle_centers()
         self.main_window.redraw_all(preserve_markers=True)
         self.update_error()
 

--- a/points.py
+++ b/points.py
@@ -104,3 +104,31 @@ class FreePoint(QGraphicsEllipseItem):
             self.main_window._draw_spline()
             return QPointF(*contour[idx])
         return super().itemChange(change, value)
+
+
+class CenterHandle(QGraphicsEllipseItem):
+    COLOR = QColor(200, 0, 200)
+
+    def __init__(self, main_window, index):
+        self.main_window = main_window
+        self.index = index
+        radius = main_window.point_radius + 2
+        super().__init__(-radius, -radius, 2 * radius, 2 * radius)
+        self.setBrush(QBrush(self.COLOR))
+        self.setPen(QPen(Qt.black, 1))
+        self.setZValue(5)
+        self.setFlag(QGraphicsEllipseItem.ItemIsMovable, True)
+        self.setFlag(QGraphicsEllipseItem.ItemSendsScenePositionChanges, True)
+        self.update_position()
+
+    def update_position(self):
+        cx, cy = self.main_window.circle_centers[self.index]
+        self.setPos(cx, cy)
+
+    def itemChange(self, change, value):
+        if change == QGraphicsEllipseItem.ItemPositionChange:
+            self.main_window.circle_centers[self.index] = (value.x(), value.y())
+            self.main_window._update_dimensions_from_centers()
+            self.main_window.redraw_all(preserve_markers=True)
+            return QPointF(*self.main_window.circle_centers[self.index])
+        return super().itemChange(change, value)


### PR DESCRIPTION
## Summary
- enable custom circle center manipulation
- track centers in MainWindow and recompute shape
- make Inspector reset centers when parameters change
- add helper functions for editing corners

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686cda89740483278b447db8609daf16