### PR TITLE
Improve arc center handling

### DIFF
--- a/geometry.py
+++ b/geometry.py
@@ -4,22 +4,45 @@ from scipy.interpolate import CubicSpline
 
 
 def arc_geom_points(a, b, R, centers=None):
-    """Return (center, start, end) tuples for each arc."""
+    """Return ``(center, start, end)`` tuples for each corner arc.
+
+    If ``centers`` is provided, the start and end points are computed so that
+    the arc of radius ``R`` remains tangent to the rectangle sides.
+    """
+
     a2, b2 = a / 2, b / 2
-    r2 = math.sqrt(2) / 2
     if centers is None:
         centers = [
-            (-a2 + R - R * r2, b2 - R + R * r2),
-            (-a2 + R - R * r2, -b2 + R - R * r2),
-            (a2 - R + R * r2, -b2 + R - R * r2),
-            (a2 - R + R * r2, b2 - R + R * r2),
+            (-a2 + R, b2 - R),
+            (-a2 + R, -b2 + R),
+            (a2 - R, -b2 + R),
+            (a2 - R, b2 - R),
         ]
-    starts_ends = [
-        ((-a2 + R, b2), (-a2, b2 - R)),
-        ((-a2, -b2 + R), (-a2 + R, -b2)),
-        ((a2 - R, -b2), (a2, -b2 + R)),
-        ((a2, b2 - R), (a2 - R, b2)),
-    ]
+
+    starts_ends = []
+    for i, (cx, cy) in enumerate(centers):
+        if i == 0:  # top-left
+            dx = math.sqrt(max(R * R - (b2 - cy) ** 2, 0.0))
+            start = (cx + dx, b2)
+            dy = math.sqrt(max(R * R - (cx + a2) ** 2, 0.0))
+            end = (-a2, cy - dy)
+        elif i == 1:  # bottom-left
+            dy = math.sqrt(max(R * R - (cx + a2) ** 2, 0.0))
+            start = (-a2, cy + dy)
+            dx = math.sqrt(max(R * R - (-b2 - cy) ** 2, 0.0))
+            end = (cx + dx, -b2)
+        elif i == 2:  # bottom-right
+            dx = math.sqrt(max(R * R - (-b2 - cy) ** 2, 0.0))
+            start = (cx - dx, -b2)
+            dy = math.sqrt(max(R * R - (cx - a2) ** 2, 0.0))
+            end = (a2, cy + dy)
+        else:  # top-right
+            dy = math.sqrt(max(R * R - (cx - a2) ** 2, 0.0))
+            start = (a2, cy - dy)
+            dx = math.sqrt(max(R * R - (b2 - cy) ** 2, 0.0))
+            end = (cx - dx, b2)
+        starts_ends.append((start, end))
+
     return [(c, s, e) for c, (s, e) in zip(centers, starts_ends)]
 
 

--- a/main_window.py
+++ b/main_window.py
@@ -1,6 +1,6 @@
 import math
 import numpy as np
-from PySide6.QtCore import Qt, QPointF
+from PySide6.QtCore import Qt, QPointF, QTimer
 from PySide6.QtGui import QPen, QBrush, QPainterPath, QColor, QFont, QTransform, QPainter
 from PySide6.QtWidgets import QGraphicsScene, QGraphicsView, QMainWindow, QDockWidget
 
@@ -46,6 +46,7 @@ class MainWindow(QMainWindow):
         dock.setAllowedAreas(Qt.RightDockWidgetArea | Qt.LeftDockWidgetArea)
         self.addDockWidget(Qt.RightDockWidgetArea, dock)
         self._marker_states = None
+        self._pending_redraw = False
         self.redraw_all()
         self._apply_transform()
 
@@ -116,6 +117,15 @@ class MainWindow(QMainWindow):
         t = QTransform()
         t.scale(self.scale, -self.scale)
         self.view.setTransform(t)
+
+    def schedule_redraw(self):
+        if not self._pending_redraw:
+            self._pending_redraw = True
+            QTimer.singleShot(30, self._do_scheduled_redraw)
+
+    def _do_scheduled_redraw(self):
+        self._pending_redraw = False
+        self.redraw_all(preserve_markers=True)
 
     def get_contour(self):
         return rounded_rect_points_centers(

--- a/points.py
+++ b/points.py
@@ -137,6 +137,6 @@ class ArcCenterPoint(QGraphicsEllipseItem):
         if change == QGraphicsEllipseItem.ItemPositionHasChanged and not self._syncing:
             pos = value if isinstance(value, QPointF) else self.pos()
             self.main_window.arc_centers[self.index] = (pos.x(), pos.y())
-            QTimer.singleShot(0, lambda: self.main_window.redraw_all(preserve_markers=True))
+            self.main_window.schedule_redraw()
             return value
         return super().itemChange(change, value)


### PR DESCRIPTION
## Summary
- compute arc start/end dynamically so moved centers stay tangent to edges
- throttle redraws when dragging arc centers

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_686fac0dd8288327af6858ed8cabc3ec