### PR TITLE
Enable draggable arc centers

### DIFF
--- a/geometry.py
+++ b/geometry.py
@@ -98,3 +98,34 @@ def cubic_spline_closed(points: np.ndarray, samples_per_seg: int = 24) -> np.nda
     cs_x = CubicSpline(t, xy[:, 0], bc_type='periodic')
     cs_y = CubicSpline(t, xy[:, 1], bc_type='periodic')
     return np.column_stack([cs_x(ts_dense), cs_y(ts_dense)])
+
+
+def rounded_rect_area(a: float, b: float, R: float, *, centers=None) -> float:
+    """Exact area of the rounded figure defined by ``centers``."""
+    if centers is None:
+        a2, b2 = a / 2, b / 2
+        centers = [
+            (-a2 + R, b2 - R),
+            (-a2 + R, -b2 + R),
+            (a2 - R, -b2 + R),
+            (a2 - R, b2 - R),
+        ]
+    ang_pairs = _arc_angles_from_centers(centers)
+    area = 0.0
+    for i in range(4):
+        cx, cy = centers[i]
+        a0, a1 = ang_pairs[i]
+        # Circular arc contribution
+        area += 0.5 * (
+            R * (cx * (math.sin(a1) - math.sin(a0)) - cy * (math.cos(a1) - math.cos(a0)))
+            + R * R * (a1 - a0)
+        )
+        j = (i + 1) % 4
+        p1 = (cx + R * math.cos(a1), cy + R * math.sin(a1))
+        p2 = (
+            centers[j][0] + R * math.cos(ang_pairs[j][0]),
+            centers[j][1] + R * math.sin(ang_pairs[j][0]),
+        )
+        # Tangent line contribution
+        area += 0.5 * (p1[0] * p2[1] - p1[1] * p2[0])
+    return abs(area)

--- a/inspector.py
+++ b/inspector.py
@@ -53,16 +53,19 @@ class InspectorWidget(QWidget):
 
     def _change_a(self, v):
         self.main_window.a = v
+        self.main_window.reset_arc_centers()
         self.main_window.redraw_all(preserve_markers=True)
         self.update_error()
 
     def _change_b(self, v):
         self.main_window.b = v
+        self.main_window.reset_arc_centers()
         self.main_window.redraw_all(preserve_markers=True)
         self.update_error()
 
     def _change_R(self, v):
         self.main_window.R = v
+        self.main_window.reset_arc_centers()
         self.main_window.redraw_all(preserve_markers=True)
         self.update_error()
 

--- a/main_window.py
+++ b/main_window.py
@@ -52,6 +52,15 @@ class MainWindow(QMainWindow):
         for cp in self.center_points:
             cp.update_radius()
 
+    def move_center(self, index, pos):
+        """Update a circle center and redraw without recursion."""
+        self.arc_centers[index] = np.array(pos)
+        for cp in self.center_points:
+            cp._syncing = True
+        self.redraw_all(preserve_markers=True)
+        for cp in self.center_points:
+            cp._syncing = False
+
     def eventFilter(self, obj, event):
         from PySide6.QtGui import QMouseEvent
         if isinstance(event, QMouseEvent) and event.type() == QMouseEvent.MouseButtonPress:
@@ -206,6 +215,7 @@ class MainWindow(QMainWindow):
         for i in range(4):
             cp = CenterPoint(self, i)
             self.scene.addItem(cp)
+            cp.finish_init()
             self.center_points.append(cp)
 
         self._prev_contour = contour.copy()

--- a/main_window.py
+++ b/main_window.py
@@ -312,22 +312,21 @@ class MainWindow(QMainWindow):
         add_text("-a", -a2 - 22, 2)
         add_text(" b", 4, b2 - 14)
         add_text("-b", 4, -b2 - 18)
+        arcs = arc_geom_points(self.a, self.b, self.R, centers=self.arc_centers)
         arc_info = [
-            (*self.arc_centers[0], math.pi / 2, math.pi),
-            (*self.arc_centers[1], math.pi, 3 * math.pi / 2),
-            (*self.arc_centers[2], 3 * math.pi / 2, 2 * math.pi),
-            (*self.arc_centers[3], 0.0, math.pi / 2),
+            (self.arc_centers[i][0], self.arc_centers[i][1], arcs[i][1], arcs[i][2])
+            for i in range(4)
         ]
         pen_c = QPen(Qt.darkGray, 1, Qt.DotLine)
         pen_c.setCosmetic(True)
         pen_r = QPen(Qt.red, 1, Qt.DashLine)
         pen_r.setCosmetic(True)
-        for cx, cy, a0, a1 in arc_info:
+        for cx, cy, start_pt, end_pt in arc_info:
             s = 6
             self.background_items.append(self.scene.addLine(cx - s, cy, cx + s, cy, pen_c))
             self.background_items.append(self.scene.addLine(cx, cy - s, cx, cy + s, pen_c))
-            p0 = QPointF(cx + R * math.cos(a0), cy + R * math.sin(a0))
-            p1 = QPointF(cx + R * math.cos(a1), cy + R * math.sin(a1))
+            p0 = QPointF(*start_pt)
+            p1 = QPointF(*end_pt)
             self.background_items.append(self.scene.addLine(cx, cy, p0.x(), p0.y(), pen_r))
             self.background_items.append(self.scene.addLine(cx, cy, p1.x(), p1.y(), pen_r))
 

--- a/main_window.py
+++ b/main_window.py
@@ -27,13 +27,13 @@ class MainWindow(QMainWindow):
         self.free_points = []
         self.spline_path = None
         self.view.viewport().installEventFilter(self)
+        self.reset_arc_centers()
         self._inspector = InspectorWidget(self)
         dock = QDockWidget("Параметры", self)
         dock.setWidget(self._inspector)
         dock.setAllowedAreas(Qt.RightDockWidgetArea | Qt.LeftDockWidgetArea)
         self.addDockWidget(Qt.RightDockWidgetArea, dock)
         self._marker_states = None
-        self.reset_arc_centers()
         self.center_points = []
         self.redraw_all()
         self._apply_transform()

--- a/main_window.py
+++ b/main_window.py
@@ -289,7 +289,10 @@ class MainWindow(QMainWindow):
     def _draw_background(self, contour):
         a2, b2, R, m = self.a / 2, self.b / 2, self.R, 40
         for it in getattr(self, 'background_items', []):
-            self.scene.removeItem(it)
+            try:
+                self.scene.removeItem(it)
+            except RuntimeError:
+                pass
         self.background_items = []
 
         pen_axis = QPen(Qt.darkGray, 1)
@@ -408,8 +411,8 @@ class MainWindow(QMainWindow):
         )
 
     def theoretical_area(self):
-        a, b, R = self.a, self.b, self.R
-        return a * b - (4 - math.pi) * (R ** 2)
+        from geometry import rounded_rect_area
+        return rounded_rect_area(self.a, self.b, self.R, centers=self.arc_centers)
 
     def area_error_percent(self):
         theory = self.theoretical_area()

--- a/points.py
+++ b/points.py
@@ -146,7 +146,9 @@ class CenterPoint(QGraphicsEllipseItem):
 
     def update_position(self):
         cx, cy = self.main_window.arc_centers[self.index]
+        self._syncing = True
         self.setPos(cx, cy)
+        self._syncing = False
 
     def update_radius(self):
         r = self.main_window.point_radius

--- a/points.py
+++ b/points.py
@@ -105,3 +105,37 @@ class FreePoint(QGraphicsEllipseItem):
             self.main_window._draw_spline()
             return QPointF(*contour[idx])
         return super().itemChange(change, value)
+
+
+class CenterPoint(QGraphicsEllipseItem):
+    COLOR = QColor(200, 50, 200)
+
+    def __init__(self, main_window, index):
+        radius = main_window.point_radius
+        super().__init__(-radius, -radius, 2 * radius, 2 * radius)
+        self.main_window = main_window
+        self.index = index
+        self._syncing = False
+        self.setBrush(QBrush(self.COLOR))
+        self.setPen(QPen(Qt.black, 1))
+        self.setZValue(5)
+        self.setFlag(QGraphicsEllipseItem.ItemIsMovable, True)
+        self.setFlag(QGraphicsEllipseItem.ItemSendsScenePositionChanges, True)
+        self.update_position()
+
+    def update_position(self):
+        cx, cy = self.main_window.arc_centers[self.index]
+        self.setPos(cx, cy)
+
+    def update_radius(self):
+        r = self.main_window.point_radius
+        self.setRect(-r, -r, 2 * r, 2 * r)
+
+    def itemChange(self, change, value):
+        if change == QGraphicsEllipseItem.ItemPositionChange:
+            if self._syncing:
+                return value
+            self.main_window.arc_centers[self.index] = np.array([value.x(), value.y()])
+            self.main_window.redraw_all(preserve_markers=True)
+            return QPointF(*self.main_window.arc_centers[self.index])
+        return super().itemChange(change, value)

--- a/points.py
+++ b/points.py
@@ -48,6 +48,8 @@ class GroupOfPoints:
         self.scene, self.main_window = scene, main_window
         self._contour = get_contour
         self.center_idx = center_idx
+        self.offsets = offsets
+        self.arc_num = arc_num
         self.offset_list = [-offsets[1], -offsets[0], 0, offsets[0], offsets[1]]
         self.points, self.ready = [], False
         contour = get_contour()
@@ -70,6 +72,15 @@ class GroupOfPoints:
 
     def get_contour(self):
         return self._contour()
+
+    def update_positions(self, contour):
+        for pt, off in zip(self.points, self.offset_list):
+            pos = self.main_window._marker_position_for_offset(
+                contour, self.center_idx, off, self.offsets, arc_num=self.arc_num
+            )
+            pt._syncing = True
+            pt.setPos(*pos)
+            pt._syncing = False
 
 
 class FreePoint(QGraphicsEllipseItem):

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,0 +1,61 @@
+import os
+import sys
+import numpy as np
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from geometry import rounded_rect_points, arc_geom_points
+
+
+def default_centers(a, b, R):
+    a2, b2 = a / 2, b / 2
+    return [
+        (-a2 + R, b2 - R),
+        (-a2 + R, -b2 + R),
+        (a2 - R, -b2 + R),
+        (a2 - R, b2 - R),
+    ]
+
+
+def test_default_bounds():
+    a, b, R = 200, 100, 20
+    pts = rounded_rect_points(a, b, R, step=1.0)
+    x_min, x_max = pts[:, 0].min(), pts[:, 0].max()
+    y_min, y_max = pts[:, 1].min(), pts[:, 1].max()
+    assert np.isclose(x_min, -a / 2)
+    assert np.isclose(x_max, a / 2)
+    assert np.isclose(y_min, -b / 2)
+    assert np.isclose(y_max, b / 2)
+
+
+def test_trapezoid_width_increase():
+    a, b, R = 200, 100, 20
+    centers = default_centers(a, b, R)
+    delta = 30
+    centers[1] = (centers[1][0] - delta, centers[1][1])
+    centers[2] = (centers[2][0] + delta, centers[2][1])
+    pts_wide = rounded_rect_points(a, b, R, step=1.0, centers=centers)
+    width_default = a
+    width_new = pts_wide[:, 0].max() - pts_wide[:, 0].min()
+    assert width_new > width_default
+
+
+def test_arc_midpoints_follow_centers():
+    a, b, R = 200, 100, 20
+    centers = default_centers(a, b, R)
+    arcs = arc_geom_points(a, b, R, centers=centers)
+    angs = [
+        (np.pi / 2, np.pi),
+        (np.pi, 3 * np.pi / 2),
+        (3 * np.pi / 2, 2 * np.pi),
+        (0.0, np.pi / 2),
+    ]
+    for center, arc, ang_pair in zip(centers, arcs, angs):
+        mid, start, end = arc
+        cx, cy = center
+        a0, a1 = ang_pair
+        exp_mid = (cx + R * np.cos((a0 + a1) / 2), cy + R * np.sin((a0 + a1) / 2))
+        exp_start = (cx + R * np.cos(a0), cy + R * np.sin(a0))
+        exp_end = (cx + R * np.cos(a1), cy + R * np.sin(a1))
+        assert np.allclose(mid, exp_mid)
+        assert np.allclose(start, exp_start)
+        assert np.allclose(end, exp_end)

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -3,7 +3,7 @@ import sys
 import numpy as np
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-from geometry import rounded_rect_points, arc_geom_points
+from geometry import rounded_rect_points, arc_geom_points, _arc_angles_from_centers
 
 
 def default_centers(a, b, R):
@@ -43,19 +43,35 @@ def test_arc_midpoints_follow_centers():
     a, b, R = 200, 100, 20
     centers = default_centers(a, b, R)
     arcs = arc_geom_points(a, b, R, centers=centers)
-    angs = [
-        (np.pi / 2, np.pi),
-        (np.pi, 3 * np.pi / 2),
-        (3 * np.pi / 2, 2 * np.pi),
-        (0.0, np.pi / 2),
-    ]
+    angs = _arc_angles_from_centers(centers)
     for center, arc, ang_pair in zip(centers, arcs, angs):
         mid, start, end = arc
         cx, cy = center
         a0, a1 = ang_pair
-        exp_mid = (cx + R * np.cos((a0 + a1) / 2), cy + R * np.sin((a0 + a1) / 2))
+        exp_mid = (
+            cx + R * np.cos((a0 + a1) / 2),
+            cy + R * np.sin((a0 + a1) / 2),
+        )
         exp_start = (cx + R * np.cos(a0), cy + R * np.sin(a0))
         exp_end = (cx + R * np.cos(a1), cy + R * np.sin(a1))
         assert np.allclose(mid, exp_mid)
         assert np.allclose(start, exp_start)
         assert np.allclose(end, exp_end)
+
+
+def test_lines_are_tangents():
+    a, b, R = 200, 100, 20
+    centers = default_centers(a, b, R)
+    centers[0] = (centers[0][0] - 10, centers[0][1] + 5)
+    centers[1] = (centers[1][0] - 20, centers[1][1] - 5)
+    arcs = arc_geom_points(a, b, R, centers=centers)
+    for i in range(4):
+        end_pt = np.array(arcs[i][2])
+        start_pt_next = np.array(arcs[(i + 1) % 4][1])
+        line_vec = start_pt_next - end_pt
+        c1 = np.array(centers[i])
+        c2 = np.array(centers[(i + 1) % 4])
+        r1 = end_pt - c1
+        r2 = start_pt_next - c2
+        assert np.isclose(np.dot(line_vec, r1), 0.0)
+        assert np.isclose(np.dot(line_vec, r2), 0.0)

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -3,7 +3,12 @@ import sys
 import numpy as np
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-from geometry import rounded_rect_points, arc_geom_points, _arc_angles_from_centers
+from geometry import (
+    rounded_rect_points,
+    arc_geom_points,
+    _arc_angles_from_centers,
+    rounded_rect_area,
+)
 
 
 def default_centers(a, b, R):
@@ -75,3 +80,19 @@ def test_lines_are_tangents():
         r2 = start_pt_next - c2
         assert np.isclose(np.dot(line_vec, r1), 0.0)
         assert np.isclose(np.dot(line_vec, r2), 0.0)
+
+
+def test_rounded_area_matches_formula():
+    a, b, R = 200, 100, 20
+    area_calc = rounded_rect_area(a, b, R)
+    expected = a * b - (4 - np.pi) * (R ** 2)
+    assert np.isclose(area_calc, expected)
+
+
+def test_area_changes_with_moved_centers():
+    a, b, R = 200, 100, 20
+    centers = default_centers(a, b, R)
+    default_area = rounded_rect_area(a, b, R, centers=centers)
+    centers[0] = (centers[0][0] - 30, centers[0][1] + 15)
+    changed = rounded_rect_area(a, b, R, centers=centers)
+    assert not np.isclose(changed, default_area)

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -1,0 +1,15 @@
+import os
+import sys
+import numpy as np
+os.environ['QT_QPA_PLATFORM'] = 'offscreen'
+from PySide6.QtWidgets import QApplication
+from main_window import MainWindow
+
+
+def test_move_center_updates_geometry():
+    app = QApplication.instance() or QApplication([])
+    win = MainWindow()
+    orig = win.arc_centers[0].copy()
+    win.move_center(0, (orig[0] + 10, orig[1] + 20))
+    app.processEvents()
+    assert np.allclose(win.arc_centers[0], [orig[0] + 10, orig[1] + 20])

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -12,3 +12,12 @@ def test_move_center_updates_geometry():
     orig = win.arc_centers[0].copy()
     win.move_center(0, (orig[0] + 10, orig[1] + 20))
     assert np.allclose(win.arc_centers[0], [orig[0] + 10, orig[1] + 20])
+
+
+def test_center_point_drag():
+    app = QApplication.instance() or QApplication([])
+    win = MainWindow()
+    cp = win.center_points[0]
+    orig = win.arc_centers[0].copy()
+    cp.setPos(orig[0] + 5, orig[1] - 5)
+    assert np.allclose(win.arc_centers[0], [orig[0] + 5, orig[1] - 5])

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -11,5 +11,4 @@ def test_move_center_updates_geometry():
     win = MainWindow()
     orig = win.arc_centers[0].copy()
     win.move_center(0, (orig[0] + 10, orig[1] + 20))
-    app.processEvents()
     assert np.allclose(win.arc_centers[0], [orig[0] + 10, orig[1] + 20])


### PR DESCRIPTION
## Summary
- let rounded rectangle geometry accept custom arc centers
- allow users to move circle centers via new `CenterPoint`
- update main window to handle and draw movable centers
- adjust inspector to reset centers on size/radius change
- test geometry helper functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fc41b384c8327b81f651500bfb924