### PR TITLE
Add editable Bezier segments

### DIFF
--- a/geometry.py
+++ b/geometry.py
@@ -22,13 +22,14 @@ def _arc_angles_from_centers(centers):
     return ang_pairs
 
 
-def arc_geom_points(a, b, R, *, centers=None, bezier_ctrl_offsets=None):
+def arc_geom_points(a, b, R, *, centers=None, bezier_ctrl_offsets=None, c1=True):
     """Return (arc_mid, start, end) tuples for each corner arc.
 
-    If ``bezier_ctrl_offsets`` are provided, arc endpoints are chosen so that
-    the circular arcs remain tangent to the adjacent Bézier segments.  This
-    keeps ``C1`` continuity at the junctions even when the handles are moved
-    freely.
+    When ``c1`` is ``True`` and ``bezier_ctrl_offsets`` are provided, arc
+    endpoints are chosen so the circular arcs remain tangent to the adjacent
+    Bézier segments (``C1`` continuity).  If ``c1`` is ``False``, offsets are
+    ignored and the arcs are taken from the fixed rectangle geometry
+    (``C0`` continuity).
     """
     if centers is None:
         a2, b2 = a / 2, b / 2
@@ -42,7 +43,7 @@ def arc_geom_points(a, b, R, *, centers=None, bezier_ctrl_offsets=None):
 
     ang_pairs = _arc_angles_from_centers(centers)
 
-    if bezier_ctrl_offsets is None:
+    if (not c1) or bezier_ctrl_offsets is None:
         arcs = []
         for (cx, cy), (a0, a1) in zip(centers, ang_pairs):
             amid = (a0 + a1) / 2
@@ -52,12 +53,12 @@ def arc_geom_points(a, b, R, *, centers=None, bezier_ctrl_offsets=None):
             arcs.append((mid, start, end))
         return arcs
 
-    # When offsets are supplied, arc endpoints depend on the Bézier tangents.
-    # ``bezier_ctrl_offsets`` is a list of four elements, one per straight
-    # segment.  Each element contains a list of ``(v1, v2)`` offset pairs for
-    # the cubic sub-segments that replace the original straight edge.  Only the
-    # first pair's ``v1`` and the last pair's ``v2`` influence the tangents for
-    # the adjoining circular arcs.
+    # When offsets are supplied and ``c1`` is True, arc endpoints depend on the
+    # Bézier tangents.  ``bezier_ctrl_offsets`` is a list of four elements, one
+    # per straight segment.  Each element contains a list of ``(v1, v2)``
+    # offset pairs for the cubic sub-segments that replace the original
+    # straight edge.  Only the first pair's ``v1`` and the last pair's ``v2``
+    # influence the tangents for the adjoining circular arcs.
     p0_list, p3_list = [], []
     for i in range(4):
         c0 = centers[i]
@@ -103,7 +104,7 @@ def arc_geom_points(a, b, R, *, centers=None, bezier_ctrl_offsets=None):
 
 
 def rounded_rect_points(a, b, R, *, step=5.0, n_arc=180, n_line=200, centers=None,
-                        bezier_ctrl_offsets=None):
+                        bezier_ctrl_offsets=None, c1=True):
     if centers is None:
         a2, b2 = a / 2.0, b / 2.0
         centers = [
@@ -156,7 +157,7 @@ def rounded_rect_points(a, b, R, *, step=5.0, n_arc=180, n_line=200, centers=Non
             [line(arcs[2][-1], arcs[3][0])],
             [line(arcs[3][-1], arcs[0][0])],
         ]
-    else:
+    elif c1:
         p0_list, p3_list, segs = [], [], []
         for i in range(4):
             c0 = centers[i]
@@ -206,6 +207,29 @@ def rounded_rect_points(a, b, R, *, step=5.0, n_arc=180, n_line=200, centers=Non
             start = p3_list[i - 1]
             end = p0_list[i]
             arcs.append(arc_from_points(cx, cy, start, end))
+    else:
+        arcs = [
+            arc_from_angles(cx, cy, a0, a1)
+            for (cx, cy), (a0, a1) in zip(centers, ang_pairs)
+        ]
+        segs = []
+        for i in range(4):
+            p0 = arcs[i][2]
+            p3 = arcs[(i + 1) % 4][1]
+            offs = bezier_ctrl_offsets[i]
+            if offs:
+                k = len(offs)
+                line_vec = p3 - p0
+                segs_i = []
+                for j, (vv1, vv2) in enumerate(offs):
+                    start = p0 + line_vec * (j / k)
+                    end = p0 + line_vec * ((j + 1) / k)
+                    p1 = start + np.asarray(vv1, dtype=float)
+                    p2 = end + np.asarray(vv2, dtype=float)
+                    segs_i.append(cubic(start, p1, p2, end))
+                segs.append(segs_i)
+            else:
+                segs.append([line(p0, p3)])
 
     dense = np.vstack([
         arcs[0], *segs[0],
@@ -255,6 +279,7 @@ def rounded_rect_area(
     *,
     centers=None,
     bezier_ctrl_offsets=None,
+    c1: bool = True,
 ) -> float:
     """Exact area of the rounded figure defined by ``centers``.
 
@@ -295,62 +320,77 @@ def rounded_rect_area(
             area += 0.5 * (p1[0] * p2[1] - p1[1] * p2[0])
         return abs(area)
 
-    p0_list = []
-    p3_list = []
-    for i in range(4):
-        c0 = centers[i]
-        c1 = centers[(i + 1) % 4]
-        offs = bezier_ctrl_offsets[i]
-        if offs:
-            v1 = np.asarray(offs[0][0], dtype=float)
-            v2 = np.asarray(offs[-1][1], dtype=float)
-        else:
-            v1 = np.zeros(2)
-            v2 = np.zeros(2)
+    if c1:
+        p0_list = []
+        p3_list = []
+        for i in range(4):
+            c0 = centers[i]
+            c1c = centers[(i + 1) % 4]
+            offs = bezier_ctrl_offsets[i]
+            if offs:
+                v1 = np.asarray(offs[0][0], dtype=float)
+                v2 = np.asarray(offs[-1][1], dtype=float)
+            else:
+                v1 = np.zeros(2)
+                v2 = np.zeros(2)
 
-        if np.linalg.norm(v1) < 1e-9:
-            ang1 = ang_pairs[i][1]
-            t0 = np.array([-math.sin(ang1), math.cos(ang1)])
-        else:
-            t0 = v1 / np.linalg.norm(v1)
+            if np.linalg.norm(v1) < 1e-9:
+                ang1 = ang_pairs[i][1]
+                t0 = np.array([-math.sin(ang1), math.cos(ang1)])
+            else:
+                t0 = v1 / np.linalg.norm(v1)
 
-        if np.linalg.norm(v2) < 1e-9:
-            ang0_next = ang_pairs[(i + 1) % 4][0]
-            t1 = np.array([-math.sin(ang0_next), math.cos(ang0_next)])
-        else:
-            t1 = (-v2) / np.linalg.norm(v2)
+            if np.linalg.norm(v2) < 1e-9:
+                ang0_next = ang_pairs[(i + 1) % 4][0]
+                t1 = np.array([-math.sin(ang0_next), math.cos(ang0_next)])
+            else:
+                t1 = (-v2) / np.linalg.norm(v2)
 
-        p0 = c0 + R * np.array([t0[1], -t0[0]])
-        p3 = c1 + R * np.array([t1[1], -t1[0]])
-        p0_list.append(p0)
-        p3_list.append(p3)
+            p0 = c0 + R * np.array([t0[1], -t0[0]])
+            p3 = c1c + R * np.array([t1[1], -t1[0]])
+            p0_list.append(p0)
+            p3_list.append(p3)
 
-        if offs:
-            k = len(offs)
-            line_vec = p3 - p0
-            for j, (vv1, vv2) in enumerate(offs):
-                start = p0 + line_vec * (j / k)
-                end = p0 + line_vec * ((j + 1) / k)
-                p1 = start + np.asarray(vv1, dtype=float)
-                p2 = end + np.asarray(vv2, dtype=float)
-                area += _cubic_area(start, p1, p2, end)
-        else:
-            area += 0.5 * (p0[0] * p3[1] - p0[1] * p3[0])
+            if offs:
+                k = len(offs)
+                line_vec = p3 - p0
+                for j, (vv1, vv2) in enumerate(offs):
+                    start = p0 + line_vec * (j / k)
+                    end = p0 + line_vec * ((j + 1) / k)
+                    p1 = start + np.asarray(vv1, dtype=float)
+                    p2 = end + np.asarray(vv2, dtype=float)
+                    area += _cubic_area(start, p1, p2, end)
+            else:
+                area += 0.5 * (p0[0] * p3[1] - p0[1] * p3[0])
 
-    for i in range(4):
-        cx, cy = centers[i]
-        start = p3_list[i - 1]
-        end = p0_list[i]
-        a0 = math.atan2(start[1] - cy, start[0] - cx)
-        a1 = math.atan2(end[1] - cy, end[0] - cx)
-        if a1 <= a0:
-            a1 += 2 * math.pi
-        area += 0.5 * (
-            R * (
-                cx * (math.sin(a1) - math.sin(a0))
-                - cy * (math.cos(a1) - math.cos(a0))
+        for i in range(4):
+            cx, cy = centers[i]
+            start = p3_list[i - 1]
+            end = p0_list[i]
+            a0 = math.atan2(start[1] - cy, start[0] - cx)
+            a1 = math.atan2(end[1] - cy, end[0] - cx)
+            if a1 <= a0:
+                a1 += 2 * math.pi
+            area += 0.5 * (
+                R * (
+                    cx * (math.sin(a1) - math.sin(a0))
+                    - cy * (math.cos(a1) - math.cos(a0))
+                )
+                + R * R * (a1 - a0)
             )
-            + R * R * (a1 - a0)
-        )
+        return abs(area)
 
-    return abs(area)
+    # For C0 continuity the arcs do not adjust to Bézier handles.  Computing an
+    # analytic area becomes cumbersome, so fall back to a dense polygon
+    # approximation of the contour.
+    pts = rounded_rect_points(
+        a,
+        b,
+        R,
+        step=0.1,
+        centers=centers,
+        bezier_ctrl_offsets=bezier_ctrl_offsets,
+        c1=False,
+    )
+    x, y = pts[:, 0], pts[:, 1]
+    return 0.5 * abs(np.dot(x, np.roll(y, -1)) - np.dot(y, np.roll(x, -1)))

--- a/geometry.py
+++ b/geometry.py
@@ -45,7 +45,7 @@ def arc_geom_points(a, b, R, *, centers=None):
 
 
 def rounded_rect_points(a, b, R, *, step=5.0, n_arc=180, n_line=200, centers=None,
-                        bezier_ctrl_lens=None):
+                        bezier_ctrl_offsets=None):
     if centers is None:
         a2, b2 = a / 2.0, b / 2.0
         centers = [
@@ -79,7 +79,7 @@ def rounded_rect_points(a, b, R, *, step=5.0, n_arc=180, n_line=200, centers=Non
     ang = _arc_angles_from_centers(centers)
     arcs = [arc(cx, cy, a0, a1) for (cx, cy), (a0, a1) in zip(centers, ang)]
 
-    if bezier_ctrl_lens is None:
+    if bezier_ctrl_offsets is None:
         segs = [
             line(arcs[0][-1], arcs[1][0]),
             line(arcs[1][-1], arcs[2][0]),
@@ -91,13 +91,9 @@ def rounded_rect_points(a, b, R, *, step=5.0, n_arc=180, n_line=200, centers=Non
         for i in range(4):
             p0 = np.asarray(arcs[i][-1])
             p3 = np.asarray(arcs[(i + 1) % 4][0])
-            l1, l2 = bezier_ctrl_lens[i]
-            ang1 = ang[i][1]
-            ang0_next = ang[(i + 1) % 4][0]
-            t0 = np.array([-math.sin(ang1), math.cos(ang1)])
-            t1 = np.array([-math.sin(ang0_next), math.cos(ang0_next)])
-            p1 = p0 + l1 * t0
-            p2 = p3 - l2 * t1
+            v1, v2 = bezier_ctrl_offsets[i]
+            p1 = p0 + np.asarray(v1)
+            p2 = p3 + np.asarray(v2)
             segs.append(cubic(p0, p1, p2, p3))
 
     dense = np.vstack([

--- a/geometry.py
+++ b/geometry.py
@@ -22,8 +22,14 @@ def _arc_angles_from_centers(centers):
     return ang_pairs
 
 
-def arc_geom_points(a, b, R, *, centers=None):
-    """Return (arc_mid, start, end) tuples for each corner arc."""
+def arc_geom_points(a, b, R, *, centers=None, bezier_ctrl_offsets=None):
+    """Return (arc_mid, start, end) tuples for each corner arc.
+
+    If ``bezier_ctrl_offsets`` are provided, arc endpoints are chosen so that
+    the circular arcs remain tangent to the adjacent Bézier segments.  This
+    keeps ``C1`` continuity at the junctions even when the handles are moved
+    freely.
+    """
     if centers is None:
         a2, b2 = a / 2, b / 2
         centers = [
@@ -32,15 +38,57 @@ def arc_geom_points(a, b, R, *, centers=None):
             (a2 - R, -b2 + R),
             (a2 - R, b2 - R),
         ]
+    centers = [np.asarray(c, dtype=float) for c in centers]
 
-    ang = _arc_angles_from_centers(centers)
+    ang_pairs = _arc_angles_from_centers(centers)
+
+    if bezier_ctrl_offsets is None:
+        arcs = []
+        for (cx, cy), (a0, a1) in zip(centers, ang_pairs):
+            amid = (a0 + a1) / 2
+            start = (cx + R * math.cos(a0), cy + R * math.sin(a0))
+            end = (cx + R * math.cos(a1), cy + R * math.sin(a1))
+            mid = (cx + R * math.cos(amid), cy + R * math.sin(amid))
+            arcs.append((mid, start, end))
+        return arcs
+
+    # When offsets are supplied, arc endpoints depend on the Bézier tangents.
+    # Compute the Bézier endpoints first to determine arc start and end.
+    p0_list, p3_list = [], []
+    for i in range(4):
+        c0 = centers[i]
+        c1 = centers[(i + 1) % 4]
+        v1, v2 = [np.asarray(v, dtype=float) for v in bezier_ctrl_offsets[i]]
+
+        if np.linalg.norm(v1) < 1e-9:
+            ang1 = ang_pairs[i][1]
+            t0 = np.array([-math.sin(ang1), math.cos(ang1)])
+        else:
+            t0 = v1 / np.linalg.norm(v1)
+
+        if np.linalg.norm(v2) < 1e-9:
+            ang0_next = ang_pairs[(i + 1) % 4][0]
+            t1 = np.array([-math.sin(ang0_next), math.cos(ang0_next)])
+        else:
+            t1 = (-v2) / np.linalg.norm(v2)
+
+        p0 = c0 + R * np.array([t0[1], -t0[0]])
+        p3 = c1 + R * np.array([t1[1], -t1[0]])
+        p0_list.append(p0)
+        p3_list.append(p3)
+
     arcs = []
-    for (cx, cy), (a0, a1) in zip(centers, ang):
+    for i in range(4):
+        c = centers[i]
+        start = p3_list[i - 1]
+        end = p0_list[i]
+        a0 = math.atan2(start[1] - c[1], start[0] - c[0])
+        a1 = math.atan2(end[1] - c[1], end[0] - c[0])
+        if a1 <= a0:
+            a1 += 2 * math.pi
         amid = (a0 + a1) / 2
-        start = (cx + R * math.cos(a0), cy + R * math.sin(a0))
-        end = (cx + R * math.cos(a1), cy + R * math.sin(a1))
-        mid = (cx + R * math.cos(amid), cy + R * math.sin(amid))
-        arcs.append((mid, start, end))
+        mid = (c[0] + R * math.cos(amid), c[1] + R * math.sin(amid))
+        arcs.append((mid, tuple(start), tuple(end)))
     return arcs
 
 
@@ -57,9 +105,18 @@ def rounded_rect_points(a, b, R, *, step=5.0, n_arc=180, n_line=200, centers=Non
     else:
         centers = [tuple(c) for c in centers]
 
-    def arc(xc, yc, ang0, ang1):
+    centers = [np.asarray(c, dtype=float) for c in centers]
+
+    def arc_from_angles(xc, yc, ang0, ang1):
         t = np.linspace(ang0, ang1, n_arc, endpoint=False)
         return np.column_stack((xc + R * np.cos(t), yc + R * np.sin(t)))
+
+    def arc_from_points(cx, cy, start, end):
+        a0 = math.atan2(start[1] - cy, start[0] - cx)
+        a1 = math.atan2(end[1] - cy, end[0] - cx)
+        if a1 <= a0:
+            a1 += 2 * math.pi
+        return arc_from_angles(cx, cy, a0, a1)
 
     def line(p0, p1):
         p0, p1 = map(np.asarray, (p0, p1))
@@ -76,10 +133,13 @@ def rounded_rect_points(a, b, R, *, step=5.0, n_arc=180, n_line=200, centers=Non
             + t ** 3 * p3
         )
 
-    ang = _arc_angles_from_centers(centers)
-    arcs = [arc(cx, cy, a0, a1) for (cx, cy), (a0, a1) in zip(centers, ang)]
+    ang_pairs = _arc_angles_from_centers(centers)
 
     if bezier_ctrl_offsets is None:
+        arcs = [
+            arc_from_angles(cx, cy, a0, a1)
+            for (cx, cy), (a0, a1) in zip(centers, ang_pairs)
+        ]
         segs = [
             line(arcs[0][-1], arcs[1][0]),
             line(arcs[1][-1], arcs[2][0]),
@@ -87,14 +147,38 @@ def rounded_rect_points(a, b, R, *, step=5.0, n_arc=180, n_line=200, centers=Non
             line(arcs[3][-1], arcs[0][0]),
         ]
     else:
-        segs = []
+        p0_list, p3_list, segs = [], [], []
         for i in range(4):
-            p0 = np.asarray(arcs[i][-1])
-            p3 = np.asarray(arcs[(i + 1) % 4][0])
-            v1, v2 = bezier_ctrl_offsets[i]
-            p1 = p0 + np.asarray(v1)
-            p2 = p3 + np.asarray(v2)
+            c0 = centers[i]
+            c1 = centers[(i + 1) % 4]
+            v1, v2 = [np.asarray(v, dtype=float) for v in bezier_ctrl_offsets[i]]
+
+            if np.linalg.norm(v1) < 1e-9:
+                ang1 = ang_pairs[i][1]
+                t0 = np.array([-math.sin(ang1), math.cos(ang1)])
+            else:
+                t0 = v1 / np.linalg.norm(v1)
+
+            if np.linalg.norm(v2) < 1e-9:
+                ang0_next = ang_pairs[(i + 1) % 4][0]
+                t1 = np.array([-math.sin(ang0_next), math.cos(ang0_next)])
+            else:
+                t1 = (-v2) / np.linalg.norm(v2)
+
+            p0 = c0 + R * np.array([t0[1], -t0[0]])
+            p3 = c1 + R * np.array([t1[1], -t1[0]])
+            p1 = p0 + v1
+            p2 = p3 + v2
+            p0_list.append(p0)
+            p3_list.append(p3)
             segs.append(cubic(p0, p1, p2, p3))
+
+        arcs = []
+        for i in range(4):
+            cx, cy = centers[i]
+            start = p3_list[i - 1]
+            end = p0_list[i]
+            arcs.append(arc_from_points(cx, cy, start, end))
 
     dense = np.vstack([
         arcs[0], segs[0],

--- a/geometry.py
+++ b/geometry.py
@@ -44,7 +44,8 @@ def arc_geom_points(a, b, R, *, centers=None):
     return arcs
 
 
-def rounded_rect_points(a, b, R, *, step=5.0, n_arc=180, n_line=200, centers=None):
+def rounded_rect_points(a, b, R, *, step=5.0, n_arc=180, n_line=200, centers=None,
+                        bezier_ctrl_lens=None):
     if centers is None:
         a2, b2 = a / 2.0, b / 2.0
         centers = [
@@ -65,19 +66,45 @@ def rounded_rect_points(a, b, R, *, step=5.0, n_arc=180, n_line=200, centers=Non
         t = np.linspace(0, 1, n_line, endpoint=False)[:, None]
         return p0 + t * (p1 - p0)
 
+    def cubic(p0, p1, p2, p3):
+        p0, p1, p2, p3 = map(np.asarray, (p0, p1, p2, p3))
+        t = np.linspace(0, 1, n_line, endpoint=False)[:, None]
+        return (
+            (1 - t) ** 3 * p0
+            + 3 * (1 - t) ** 2 * t * p1
+            + 3 * (1 - t) * t ** 2 * p2
+            + t ** 3 * p3
+        )
+
     ang = _arc_angles_from_centers(centers)
     arcs = [arc(cx, cy, a0, a1) for (cx, cy), (a0, a1) in zip(centers, ang)]
-    lines = [
-        line(arcs[0][-1], arcs[1][0]),
-        line(arcs[1][-1], arcs[2][0]),
-        line(arcs[2][-1], arcs[3][0]),
-        line(arcs[3][-1], arcs[0][0]),
-    ]
+
+    if bezier_ctrl_lens is None:
+        segs = [
+            line(arcs[0][-1], arcs[1][0]),
+            line(arcs[1][-1], arcs[2][0]),
+            line(arcs[2][-1], arcs[3][0]),
+            line(arcs[3][-1], arcs[0][0]),
+        ]
+    else:
+        segs = []
+        for i in range(4):
+            p0 = np.asarray(arcs[i][-1])
+            p3 = np.asarray(arcs[(i + 1) % 4][0])
+            l1, l2 = bezier_ctrl_lens[i]
+            ang1 = ang[i][1]
+            ang0_next = ang[(i + 1) % 4][0]
+            t0 = np.array([-math.sin(ang1), math.cos(ang1)])
+            t1 = np.array([-math.sin(ang0_next), math.cos(ang0_next)])
+            p1 = p0 + l1 * t0
+            p2 = p3 - l2 * t1
+            segs.append(cubic(p0, p1, p2, p3))
+
     dense = np.vstack([
-        arcs[0], lines[0],
-        arcs[1], lines[1],
-        arcs[2], lines[2],
-        arcs[3], lines[3],
+        arcs[0], segs[0],
+        arcs[1], segs[1],
+        arcs[2], segs[2],
+        arcs[3], segs[3],
     ])
     seg = np.linalg.norm(np.diff(dense, axis=0, append=dense[:1]), axis=1)
     s = np.concatenate(([0.0], np.cumsum(seg[:-1])))

--- a/geometry.py
+++ b/geometry.py
@@ -53,12 +53,22 @@ def arc_geom_points(a, b, R, *, centers=None, bezier_ctrl_offsets=None):
         return arcs
 
     # When offsets are supplied, arc endpoints depend on the Bézier tangents.
-    # Compute the Bézier endpoints first to determine arc start and end.
+    # ``bezier_ctrl_offsets`` is a list of four elements, one per straight
+    # segment.  Each element contains a list of ``(v1, v2)`` offset pairs for
+    # the cubic sub-segments that replace the original straight edge.  Only the
+    # first pair's ``v1`` and the last pair's ``v2`` influence the tangents for
+    # the adjoining circular arcs.
     p0_list, p3_list = [], []
     for i in range(4):
         c0 = centers[i]
         c1 = centers[(i + 1) % 4]
-        v1, v2 = [np.asarray(v, dtype=float) for v in bezier_ctrl_offsets[i]]
+        offs = bezier_ctrl_offsets[i]
+        if offs:
+            v1 = np.asarray(offs[0][0], dtype=float)
+            v2 = np.asarray(offs[-1][1], dtype=float)
+        else:
+            v1 = np.zeros(2)
+            v2 = np.zeros(2)
 
         if np.linalg.norm(v1) < 1e-9:
             ang1 = ang_pairs[i][1]
@@ -141,17 +151,23 @@ def rounded_rect_points(a, b, R, *, step=5.0, n_arc=180, n_line=200, centers=Non
             for (cx, cy), (a0, a1) in zip(centers, ang_pairs)
         ]
         segs = [
-            line(arcs[0][-1], arcs[1][0]),
-            line(arcs[1][-1], arcs[2][0]),
-            line(arcs[2][-1], arcs[3][0]),
-            line(arcs[3][-1], arcs[0][0]),
+            [line(arcs[0][-1], arcs[1][0])],
+            [line(arcs[1][-1], arcs[2][0])],
+            [line(arcs[2][-1], arcs[3][0])],
+            [line(arcs[3][-1], arcs[0][0])],
         ]
     else:
         p0_list, p3_list, segs = [], [], []
         for i in range(4):
             c0 = centers[i]
             c1 = centers[(i + 1) % 4]
-            v1, v2 = [np.asarray(v, dtype=float) for v in bezier_ctrl_offsets[i]]
+            offs = bezier_ctrl_offsets[i]
+            if offs:
+                v1 = np.asarray(offs[0][0], dtype=float)
+                v2 = np.asarray(offs[-1][1], dtype=float)
+            else:
+                v1 = np.zeros(2)
+                v2 = np.zeros(2)
 
             if np.linalg.norm(v1) < 1e-9:
                 ang1 = ang_pairs[i][1]
@@ -167,11 +183,22 @@ def rounded_rect_points(a, b, R, *, step=5.0, n_arc=180, n_line=200, centers=Non
 
             p0 = c0 + R * np.array([t0[1], -t0[0]])
             p3 = c1 + R * np.array([t1[1], -t1[0]])
-            p1 = p0 + v1
-            p2 = p3 + v2
             p0_list.append(p0)
             p3_list.append(p3)
-            segs.append(cubic(p0, p1, p2, p3))
+
+            if offs:
+                k = len(offs)
+                line_vec = p3 - p0
+                segs_i = []
+                for j, (vv1, vv2) in enumerate(offs):
+                    start = p0 + line_vec * (j / k)
+                    end = p0 + line_vec * ((j + 1) / k)
+                    p1 = start + np.asarray(vv1, dtype=float)
+                    p2 = end + np.asarray(vv2, dtype=float)
+                    segs_i.append(cubic(start, p1, p2, end))
+                segs.append(segs_i)
+            else:
+                segs.append([line(p0, p3)])
 
         arcs = []
         for i in range(4):
@@ -181,10 +208,10 @@ def rounded_rect_points(a, b, R, *, step=5.0, n_arc=180, n_line=200, centers=Non
             arcs.append(arc_from_points(cx, cy, start, end))
 
     dense = np.vstack([
-        arcs[0], segs[0],
-        arcs[1], segs[1],
-        arcs[2], segs[2],
-        arcs[3], segs[3],
+        arcs[0], *segs[0],
+        arcs[1], *segs[1],
+        arcs[2], *segs[2],
+        arcs[3], *segs[3],
     ])
     seg = np.linalg.norm(np.diff(dense, axis=0, append=dense[:1]), axis=1)
     s = np.concatenate(([0.0], np.cumsum(seg[:-1])))
@@ -273,7 +300,13 @@ def rounded_rect_area(
     for i in range(4):
         c0 = centers[i]
         c1 = centers[(i + 1) % 4]
-        v1, v2 = [np.asarray(v, dtype=float) for v in bezier_ctrl_offsets[i]]
+        offs = bezier_ctrl_offsets[i]
+        if offs:
+            v1 = np.asarray(offs[0][0], dtype=float)
+            v2 = np.asarray(offs[-1][1], dtype=float)
+        else:
+            v1 = np.zeros(2)
+            v2 = np.zeros(2)
 
         if np.linalg.norm(v1) < 1e-9:
             ang1 = ang_pairs[i][1]
@@ -289,11 +322,20 @@ def rounded_rect_area(
 
         p0 = c0 + R * np.array([t0[1], -t0[0]])
         p3 = c1 + R * np.array([t1[1], -t1[0]])
-        p1 = p0 + v1
-        p2 = p3 + v2
         p0_list.append(p0)
         p3_list.append(p3)
-        area += _cubic_area(p0, p1, p2, p3)
+
+        if offs:
+            k = len(offs)
+            line_vec = p3 - p0
+            for j, (vv1, vv2) in enumerate(offs):
+                start = p0 + line_vec * (j / k)
+                end = p0 + line_vec * ((j + 1) / k)
+                p1 = start + np.asarray(vv1, dtype=float)
+                p2 = end + np.asarray(vv2, dtype=float)
+                area += _cubic_area(start, p1, p2, end)
+        else:
+            area += 0.5 * (p0[0] * p3[1] - p0[1] * p3[0])
 
     for i in range(4):
         cx, cy = centers[i]

--- a/geometry.py
+++ b/geometry.py
@@ -207,8 +207,34 @@ def cubic_spline_closed(points: np.ndarray, samples_per_seg: int = 24) -> np.nda
     return np.column_stack([cs_x(ts_dense), cs_y(ts_dense)])
 
 
-def rounded_rect_area(a: float, b: float, R: float, *, centers=None) -> float:
-    """Exact area of the rounded figure defined by ``centers``."""
+def _cubic_area(p0, p1, p2, p3):
+    """Signed area enclosed by a cubic Bézier segment."""
+    x0, y0 = p0
+    x1, y1 = p1
+    x2, y2 = p2
+    x3, y3 = p3
+    return 0.5 * (1 / 20) * (
+        12 * x0 * y1 + 6 * x0 * y2 + 2 * x0 * y3
+        - 12 * x1 * y0 + 6 * x1 * y2 + 6 * x1 * y3
+        - 6 * x2 * y0 - 6 * x2 * y1 + 12 * x2 * y3
+        - 2 * x3 * y0 - 6 * x3 * y1 - 12 * x3 * y2
+    )
+
+
+def rounded_rect_area(
+    a: float,
+    b: float,
+    R: float,
+    *,
+    centers=None,
+    bezier_ctrl_offsets=None,
+) -> float:
+    """Exact area of the rounded figure defined by ``centers``.
+
+    When ``bezier_ctrl_offsets`` are provided, straight edges are replaced by
+    cubic Bézier segments with the given control-point offsets, and the area
+    accounts for these curves.
+    """
     if centers is None:
         a2, b2 = a / 2, b / 2
         centers = [
@@ -217,22 +243,72 @@ def rounded_rect_area(a: float, b: float, R: float, *, centers=None) -> float:
             (a2 - R, -b2 + R),
             (a2 - R, b2 - R),
         ]
+
+    centers = [np.asarray(c, dtype=float) for c in centers]
     ang_pairs = _arc_angles_from_centers(centers)
     area = 0.0
+
+    if bezier_ctrl_offsets is None:
+        for i in range(4):
+            cx, cy = centers[i]
+            a0, a1 = ang_pairs[i]
+            area += 0.5 * (
+                R * (
+                    cx * (math.sin(a1) - math.sin(a0))
+                    - cy * (math.cos(a1) - math.cos(a0))
+                )
+                + R * R * (a1 - a0)
+            )
+            j = (i + 1) % 4
+            p1 = (cx + R * math.cos(a1), cy + R * math.sin(a1))
+            p2 = (
+                centers[j][0] + R * math.cos(ang_pairs[j][0]),
+                centers[j][1] + R * math.sin(ang_pairs[j][0]),
+            )
+            area += 0.5 * (p1[0] * p2[1] - p1[1] * p2[0])
+        return abs(area)
+
+    p0_list = []
+    p3_list = []
+    for i in range(4):
+        c0 = centers[i]
+        c1 = centers[(i + 1) % 4]
+        v1, v2 = [np.asarray(v, dtype=float) for v in bezier_ctrl_offsets[i]]
+
+        if np.linalg.norm(v1) < 1e-9:
+            ang1 = ang_pairs[i][1]
+            t0 = np.array([-math.sin(ang1), math.cos(ang1)])
+        else:
+            t0 = v1 / np.linalg.norm(v1)
+
+        if np.linalg.norm(v2) < 1e-9:
+            ang0_next = ang_pairs[(i + 1) % 4][0]
+            t1 = np.array([-math.sin(ang0_next), math.cos(ang0_next)])
+        else:
+            t1 = (-v2) / np.linalg.norm(v2)
+
+        p0 = c0 + R * np.array([t0[1], -t0[0]])
+        p3 = c1 + R * np.array([t1[1], -t1[0]])
+        p1 = p0 + v1
+        p2 = p3 + v2
+        p0_list.append(p0)
+        p3_list.append(p3)
+        area += _cubic_area(p0, p1, p2, p3)
+
     for i in range(4):
         cx, cy = centers[i]
-        a0, a1 = ang_pairs[i]
-        # Circular arc contribution
+        start = p3_list[i - 1]
+        end = p0_list[i]
+        a0 = math.atan2(start[1] - cy, start[0] - cx)
+        a1 = math.atan2(end[1] - cy, end[0] - cx)
+        if a1 <= a0:
+            a1 += 2 * math.pi
         area += 0.5 * (
-            R * (cx * (math.sin(a1) - math.sin(a0)) - cy * (math.cos(a1) - math.cos(a0)))
+            R * (
+                cx * (math.sin(a1) - math.sin(a0))
+                - cy * (math.cos(a1) - math.cos(a0))
+            )
             + R * R * (a1 - a0)
         )
-        j = (i + 1) % 4
-        p1 = (cx + R * math.cos(a1), cy + R * math.sin(a1))
-        p2 = (
-            centers[j][0] + R * math.cos(ang_pairs[j][0]),
-            centers[j][1] + R * math.sin(ang_pairs[j][0]),
-        )
-        # Tangent line contribution
-        area += 0.5 * (p1[0] * p2[1] - p1[1] * p2[0])
+
     return abs(area)

--- a/inspector.py
+++ b/inspector.py
@@ -121,6 +121,7 @@ class InspectorWidget(QWidget):
 
     def _change_continuity(self, idx):
         self.main_window.c1 = (idx == 0)
+        self.main_window.compute_default_bezier_offsets()
         self.main_window.redraw_all(preserve_markers=True)
         self.update_error()
 

--- a/inspector.py
+++ b/inspector.py
@@ -20,6 +20,7 @@ class InspectorWidget(QWidget):
         self.scale = self._add_dspinbox("Масштаб", 0.1, 4.0, main_window.scale, self._change_scale, decimals=2, step=0.05)
         self.step = self._add_dspinbox("Шаг дискретизации", 0.1, 100, main_window.step, self._change_step, decimals=2, step=0.1)
         self.bezier_pts = self._add_spinbox("Точек на Безье", 4, 2000, main_window.bezier_points, self._change_bezier_pts)
+        self.bezier_ctrls = self._add_spinbox("Контрольные точки", 0, 20, main_window.bezier_ctrl_count, self._change_bezier_ctrls, step=2)
         self.layout.addRow(QLabel("<b>Визуализация</b>"))
         self.point_radius = self._add_spinbox("Размер точек", 1, 50, main_window.point_radius, self._change_point_radius)
         self.line_width = self._add_spinbox("Толщина линий", 1, 15, main_window.line_width, self._change_line_width)
@@ -55,9 +56,10 @@ class InspectorWidget(QWidget):
         self.layout.addRow(label, w)
         return w
 
-    def _add_spinbox(self, label, mn, mx, val, slot):
+    def _add_spinbox(self, label, mn, mx, val, slot, step=1):
         w = QSpinBox()
         w.setRange(mn, mx)
+        w.setSingleStep(step)
         w.setValue(val)
         w.valueChanged.connect(slot)
         self.layout.addRow(label, w)
@@ -105,6 +107,10 @@ class InspectorWidget(QWidget):
     def _change_bezier_pts(self, v):
         self.main_window.bezier_points = v
         self.main_window.redraw_all(preserve_markers=True)
+        self.update_error()
+
+    def _change_bezier_ctrls(self, v):
+        self.main_window.change_bezier_ctrl_count(v)
         self.update_error()
 
     def _optimize(self):

--- a/inspector.py
+++ b/inspector.py
@@ -19,6 +19,7 @@ class InspectorWidget(QWidget):
         self.R = self._add_dspinbox("R (радиус скругления)", 1, 1000, main_window.R, self._change_R)
         self.scale = self._add_dspinbox("Масштаб", 0.1, 4.0, main_window.scale, self._change_scale, decimals=2, step=0.05)
         self.step = self._add_dspinbox("Шаг дискретизации", 0.1, 100, main_window.step, self._change_step, decimals=2, step=0.1)
+        self.bezier_pts = self._add_spinbox("Точек на Безье", 4, 2000, main_window.bezier_points, self._change_bezier_pts)
         self.layout.addRow(QLabel("<b>Визуализация</b>"))
         self.point_radius = self._add_spinbox("Размер точек", 1, 50, main_window.point_radius, self._change_point_radius)
         self.line_width = self._add_spinbox("Толщина линий", 1, 15, main_window.line_width, self._change_line_width)
@@ -98,6 +99,11 @@ class InspectorWidget(QWidget):
 
     def _change_step(self, v):
         self.main_window.step = v
+        self.main_window.redraw_all(preserve_markers=True)
+        self.update_error()
+
+    def _change_bezier_pts(self, v):
+        self.main_window.bezier_points = v
         self.main_window.redraw_all(preserve_markers=True)
         self.update_error()
 

--- a/inspector.py
+++ b/inspector.py
@@ -5,6 +5,7 @@ from PySide6.QtWidgets import (
     QSpinBox,
     QLabel,
     QPushButton,
+    QComboBox,
 )
 
 
@@ -21,6 +22,11 @@ class InspectorWidget(QWidget):
         self.step = self._add_dspinbox("Шаг дискретизации", 0.1, 100, main_window.step, self._change_step, decimals=2, step=0.1)
         self.bezier_pts = self._add_spinbox("Точек на Безье", 4, 2000, main_window.bezier_points, self._change_bezier_pts)
         self.bezier_ctrls = self._add_spinbox("Контрольные точки", 0, 20, main_window.bezier_ctrl_count, self._change_bezier_ctrls, step=2)
+        self.continuity = QComboBox()
+        self.continuity.addItems(["C1", "C0"])
+        self.continuity.setCurrentIndex(0 if main_window.c1 else 1)
+        self.continuity.currentIndexChanged.connect(self._change_continuity)
+        self.layout.addRow("Гладкость", self.continuity)
         self.layout.addRow(QLabel("<b>Визуализация</b>"))
         self.point_radius = self._add_spinbox("Размер точек", 1, 50, main_window.point_radius, self._change_point_radius)
         self.line_width = self._add_spinbox("Толщина линий", 1, 15, main_window.line_width, self._change_line_width)
@@ -111,6 +117,11 @@ class InspectorWidget(QWidget):
 
     def _change_bezier_ctrls(self, v):
         self.main_window.change_bezier_ctrl_count(v)
+        self.update_error()
+
+    def _change_continuity(self, idx):
+        self.main_window.c1 = (idx == 0)
+        self.main_window.redraw_all(preserve_markers=True)
         self.update_error()
 
     def _optimize(self):

--- a/main_window.py
+++ b/main_window.py
@@ -4,10 +4,10 @@ from PySide6.QtCore import Qt, QPointF
 from PySide6.QtGui import QPen, QBrush, QPainterPath, QColor, QFont, QTransform, QPainter
 from PySide6.QtWidgets import QGraphicsScene, QGraphicsView, QMainWindow, QDockWidget
 
-from geometry import arc_geom_points, rounded_rect_points, cubic_spline_closed
+from geometry import arc_geom_points, rounded_rect_points, cubic_spline_closed, _arc_angles_from_centers
 from scipy.interpolate import CubicSpline
 from scipy.optimize import minimize
-from points import GroupOfPoints, FreePoint, CenterPoint
+from points import GroupOfPoints, FreePoint, CenterPoint, BezierCtrlPoint
 from inspector import InspectorWidget
 
 
@@ -30,6 +30,8 @@ class MainWindow(QMainWindow):
         self.contour_item = None
         self.background_items = []
         self.view.viewport().installEventFilter(self)
+        self.bezier_ctrl_lens = []
+        self.bezier_ctrl_points = []
         self.reset_arc_centers()
         self._inspector = InspectorWidget(self)
         dock = QDockWidget("Параметры", self)
@@ -48,12 +50,60 @@ class MainWindow(QMainWindow):
             np.array([self.a / 2 - self.R, -self.b / 2 + self.R]),
             np.array([self.a / 2 - self.R, self.b / 2 - self.R]),
         ]
+        self.compute_default_bezier_lens()
+
+    def compute_default_bezier_lens(self):
+        arcs = arc_geom_points(self.a, self.b, self.R, centers=self.arc_centers)
+        self.bezier_ctrl_lens = []
+        for i in range(4):
+            p0 = np.array(arcs[i][2])
+            p3 = np.array(arcs[(i + 1) % 4][1])
+            chord = np.linalg.norm(p3 - p0)
+            d = chord / 3.0
+            self.bezier_ctrl_lens.append([d, d])
+
+    def _bezier_endpoints(self, seg_idx):
+        ang = _arc_angles_from_centers(self.arc_centers)
+        arcs = arc_geom_points(self.a, self.b, self.R, centers=self.arc_centers)
+        p0 = np.array(arcs[seg_idx][2])
+        p3 = np.array(arcs[(seg_idx + 1) % 4][1])
+        ang1 = ang[seg_idx][1]
+        ang0_next = ang[(seg_idx + 1) % 4][0]
+        t0 = np.array([-math.sin(ang1), math.cos(ang1)])
+        t1 = np.array([-math.sin(ang0_next), math.cos(ang0_next)])
+        return p0, p3, t0, t1
+
+    def bezier_ctrl_position(self, seg_idx, ctrl_idx):
+        p0, p3, t0, t1 = self._bezier_endpoints(seg_idx)
+        l1, l2 = self.bezier_ctrl_lens[seg_idx]
+        if ctrl_idx == 0:
+            return p0 + l1 * t0
+        else:
+            return p3 - l2 * t1
+
+    def update_after_bezier_move(self):
+        contour = self.get_contour()
+        for grp in self.groups:
+            grp.update_positions(contour)
+        for fp in self.free_points:
+            fp.update_position()
+        for pair in self.bezier_ctrl_points:
+            for cp in pair:
+                if not cp._syncing:
+                    cp.update_position()
+        self._draw_background(contour)
+        self._draw_contour(contour)
+        self._draw_spline()
+        self._prev_contour = contour.copy()
 
     def update_free_points_radius(self):
         for fp in self.free_points:
             fp.update_radius()
         for cp in self.center_points:
             cp.update_radius()
+        for pair in self.bezier_ctrl_points:
+            for bp in pair:
+                bp.update_radius()
 
     def move_center(self, index, pos):
         """Update a circle center and redraw geometry immediately."""
@@ -131,6 +181,7 @@ class MainWindow(QMainWindow):
             self.R,
             step=self.step,
             centers=self.arc_centers,
+            bezier_ctrl_lens=self.bezier_ctrl_lens,
         )
 
     def arc_center_indices(self, contour):
@@ -150,6 +201,9 @@ class MainWindow(QMainWindow):
         for cp in self.center_points:
             if not cp._syncing:
                 cp.update_position()
+        for pair in self.bezier_ctrl_points:
+            for bp in pair:
+                bp.update_position()
         self._draw_background(contour)
         self._draw_contour(contour)
         self._draw_spline()
@@ -236,6 +290,16 @@ class MainWindow(QMainWindow):
             self.scene.addItem(cp)
             cp.finish_init()
             self.center_points.append(cp)
+
+        self.bezier_ctrl_points = []
+        for i in range(4):
+            cp1 = BezierCtrlPoint(self, i, 0)
+            cp2 = BezierCtrlPoint(self, i, 1)
+            self.scene.addItem(cp1)
+            self.scene.addItem(cp2)
+            cp1.finish_init()
+            cp2.finish_init()
+            self.bezier_ctrl_points.append((cp1, cp2))
 
         self._prev_contour = contour.copy()
         self._draw_background(contour)

--- a/main_window.py
+++ b/main_window.py
@@ -30,7 +30,7 @@ class MainWindow(QMainWindow):
         self.contour_item = None
         self.background_items = []
         self.view.viewport().installEventFilter(self)
-        self.bezier_ctrl_lens = []
+        self.bezier_ctrl_offsets = []
         self.bezier_ctrl_points = []
         self.reset_arc_centers()
         self._inspector = InspectorWidget(self)
@@ -50,17 +50,24 @@ class MainWindow(QMainWindow):
             np.array([self.a / 2 - self.R, -self.b / 2 + self.R]),
             np.array([self.a / 2 - self.R, self.b / 2 - self.R]),
         ]
-        self.compute_default_bezier_lens()
+        self.compute_default_bezier_offsets()
 
-    def compute_default_bezier_lens(self):
+    def compute_default_bezier_offsets(self):
         arcs = arc_geom_points(self.a, self.b, self.R, centers=self.arc_centers)
-        self.bezier_ctrl_lens = []
+        self.bezier_ctrl_offsets = []
+        ang = _arc_angles_from_centers(self.arc_centers)
         for i in range(4):
             p0 = np.array(arcs[i][2])
             p3 = np.array(arcs[(i + 1) % 4][1])
             chord = np.linalg.norm(p3 - p0)
             d = chord / 3.0
-            self.bezier_ctrl_lens.append([d, d])
+            ang1 = ang[i][1]
+            ang0_next = ang[(i + 1) % 4][0]
+            t0 = np.array([-math.sin(ang1), math.cos(ang1)])
+            t1 = np.array([-math.sin(ang0_next), math.cos(ang0_next)])
+            v1 = d * t0
+            v2 = -d * t1
+            self.bezier_ctrl_offsets.append([v1, v2])
 
     def _bezier_endpoints(self, seg_idx):
         ang = _arc_angles_from_centers(self.arc_centers)
@@ -75,11 +82,11 @@ class MainWindow(QMainWindow):
 
     def bezier_ctrl_position(self, seg_idx, ctrl_idx):
         p0, p3, t0, t1 = self._bezier_endpoints(seg_idx)
-        l1, l2 = self.bezier_ctrl_lens[seg_idx]
+        v1, v2 = self.bezier_ctrl_offsets[seg_idx]
         if ctrl_idx == 0:
-            return p0 + l1 * t0
+            return p0 + v1
         else:
-            return p3 - l2 * t1
+            return p3 + v2
 
     def update_after_bezier_move(self):
         contour = self.get_contour()
@@ -181,7 +188,7 @@ class MainWindow(QMainWindow):
             self.R,
             step=self.step,
             centers=self.arc_centers,
-            bezier_ctrl_lens=self.bezier_ctrl_lens,
+            bezier_ctrl_offsets=self.bezier_ctrl_offsets,
         )
 
     def arc_center_indices(self, contour):

--- a/main_window.py
+++ b/main_window.py
@@ -513,7 +513,13 @@ class MainWindow(QMainWindow):
 
     def theoretical_area(self):
         from geometry import rounded_rect_area
-        return rounded_rect_area(self.a, self.b, self.R, centers=self.arc_centers)
+        return rounded_rect_area(
+            self.a,
+            self.b,
+            self.R,
+            centers=self.arc_centers,
+            bezier_ctrl_offsets=self.bezier_ctrl_offsets,
+        )
 
     def area_error_percent(self):
         theory = self.theoretical_area()

--- a/main_window.py
+++ b/main_window.py
@@ -71,13 +71,24 @@ class MainWindow(QMainWindow):
 
     def _bezier_endpoints(self, seg_idx):
         ang = _arc_angles_from_centers(self.arc_centers)
-        arcs = arc_geom_points(self.a, self.b, self.R, centers=self.arc_centers)
-        p0 = np.array(arcs[seg_idx][2])
-        p3 = np.array(arcs[(seg_idx + 1) % 4][1])
-        ang1 = ang[seg_idx][1]
-        ang0_next = ang[(seg_idx + 1) % 4][0]
-        t0 = np.array([-math.sin(ang1), math.cos(ang1)])
-        t1 = np.array([-math.sin(ang0_next), math.cos(ang0_next)])
+        v1, v2 = [np.asarray(v, dtype=float) for v in self.bezier_ctrl_offsets[seg_idx]]
+        c0 = np.asarray(self.arc_centers[seg_idx], dtype=float)
+        c1 = np.asarray(self.arc_centers[(seg_idx + 1) % 4], dtype=float)
+
+        if np.linalg.norm(v1) < 1e-9:
+            ang1 = ang[seg_idx][1]
+            t0 = np.array([-math.sin(ang1), math.cos(ang1)])
+        else:
+            t0 = v1 / np.linalg.norm(v1)
+
+        if np.linalg.norm(v2) < 1e-9:
+            ang0_next = ang[(seg_idx + 1) % 4][0]
+            t1 = np.array([-math.sin(ang0_next), math.cos(ang0_next)])
+        else:
+            t1 = (-v2) / np.linalg.norm(v2)
+
+        p0 = c0 + self.R * np.array([t0[1], -t0[0]])
+        p3 = c1 + self.R * np.array([t1[1], -t1[0]])
         return p0, p3, t0, t1
 
     def bezier_ctrl_position(self, seg_idx, ctrl_idx):
@@ -192,7 +203,11 @@ class MainWindow(QMainWindow):
         )
 
     def arc_center_indices(self, contour):
-        arcs = arc_geom_points(self.a, self.b, self.R, centers=self.arc_centers)
+        arcs = arc_geom_points(
+            self.a, self.b, self.R,
+            centers=self.arc_centers,
+            bezier_ctrl_offsets=self.bezier_ctrl_offsets,
+        )
         centers_geom = [arc[0] for arc in arcs]
         return [int(np.argmin(np.linalg.norm(contour - np.array(pt), axis=1))) for pt in centers_geom]
 
@@ -217,7 +232,14 @@ class MainWindow(QMainWindow):
         self._prev_contour = contour.copy()
 
     def _marker_position_for_offset(self, contour, _, offset, offsets, arc_num):
-        center_xy, start_xy, end_xy = [np.array(p) for p in arc_geom_points(self.a, self.b, self.R, centers=self.arc_centers)[arc_num]]
+        center_xy, start_xy, end_xy = [
+            np.array(p)
+            for p in arc_geom_points(
+                self.a, self.b, self.R,
+                centers=self.arc_centers,
+                bezier_ctrl_offsets=self.bezier_ctrl_offsets,
+            )[arc_num]
+        ]
         center_idx = np.argmin(np.linalg.norm(contour - center_xy, axis=1))
         start_idx = np.argmin(np.linalg.norm(contour - start_xy, axis=1))
         end_idx = np.argmin(np.linalg.norm(contour - end_xy, axis=1))
@@ -390,7 +412,11 @@ class MainWindow(QMainWindow):
         add_text("-a", -a2 - 22, 2)
         add_text(" b", 4, b2 - 14)
         add_text("-b", 4, -b2 - 18)
-        arcs = arc_geom_points(self.a, self.b, self.R, centers=self.arc_centers)
+        arcs = arc_geom_points(
+            self.a, self.b, self.R,
+            centers=self.arc_centers,
+            bezier_ctrl_offsets=self.bezier_ctrl_offsets,
+        )
         arc_info = [
             (self.arc_centers[i][0], self.arc_centers[i][1], arcs[i][1], arcs[i][2])
             for i in range(4)
@@ -506,7 +532,11 @@ class MainWindow(QMainWindow):
         N = len(contour)
 
         # Determine metadata for the four straight segments
-        arcs = arc_geom_points(self.a, self.b, self.R, centers=self.arc_centers)
+        arcs = arc_geom_points(
+            self.a, self.b, self.R,
+            centers=self.arc_centers,
+            bezier_ctrl_offsets=self.bezier_ctrl_offsets,
+        )
         line_meta = []
         for i in range(4):
             start_pt = np.array(arcs[i][2])

--- a/main_window.py
+++ b/main_window.py
@@ -56,7 +56,13 @@ class MainWindow(QMainWindow):
         self.compute_default_bezier_offsets()
 
     def compute_default_bezier_offsets(self):
-        arcs = arc_geom_points(self.a, self.b, self.R, centers=self.arc_centers)
+        arcs = arc_geom_points(
+            self.a,
+            self.b,
+            self.R,
+            centers=self.arc_centers,
+            c1=self.c1,
+        )
         self.bezier_ctrl_offsets = []
         n = self.bezier_ctrl_count // 2
         for i in range(4):
@@ -266,9 +272,12 @@ class MainWindow(QMainWindow):
         center_xy, start_xy, end_xy = [
             np.array(p)
             for p in arc_geom_points(
-                self.a, self.b, self.R,
+                self.a,
+                self.b,
+                self.R,
                 centers=self.arc_centers,
                 bezier_ctrl_offsets=self.bezier_ctrl_offsets,
+                c1=self.c1,
             )[arc_num]
         ]
         center_idx = np.argmin(np.linalg.norm(contour - center_xy, axis=1))

--- a/main_window.py
+++ b/main_window.py
@@ -22,6 +22,7 @@ class MainWindow(QMainWindow):
         self.step = 1.0
         self.bezier_points = 200
         self.bezier_ctrl_count = 2  # control points per straight side
+        self.c1 = True
         self.scene = QGraphicsScene()
         self.view = QGraphicsView(self.scene)
         self.view.setRenderHint(QPainter.Antialiasing, True)
@@ -77,32 +78,42 @@ class MainWindow(QMainWindow):
         self.redraw_all(preserve_markers=True)
 
     def _bezier_line_endpoints(self, side_idx):
-        ang = _arc_angles_from_centers(self.arc_centers)
-        offs = self.bezier_ctrl_offsets[side_idx]
-        if offs:
-            v1 = np.asarray(offs[0][0], dtype=float)
-            v2 = np.asarray(offs[-1][1], dtype=float)
-        else:
-            v1 = np.zeros(2)
-            v2 = np.zeros(2)
-        c0 = np.asarray(self.arc_centers[side_idx], dtype=float)
-        c1 = np.asarray(self.arc_centers[(side_idx + 1) % 4], dtype=float)
+        if self.c1:
+            ang = _arc_angles_from_centers(self.arc_centers)
+            offs = self.bezier_ctrl_offsets[side_idx]
+            if offs:
+                v1 = np.asarray(offs[0][0], dtype=float)
+                v2 = np.asarray(offs[-1][1], dtype=float)
+            else:
+                v1 = np.zeros(2)
+                v2 = np.zeros(2)
+            c0 = np.asarray(self.arc_centers[side_idx], dtype=float)
+            c1c = np.asarray(self.arc_centers[(side_idx + 1) % 4], dtype=float)
 
-        if np.linalg.norm(v1) < 1e-9:
-            ang1 = ang[side_idx][1]
-            t0 = np.array([-math.sin(ang1), math.cos(ang1)])
-        else:
-            t0 = v1 / np.linalg.norm(v1)
+            if np.linalg.norm(v1) < 1e-9:
+                ang1 = ang[side_idx][1]
+                t0 = np.array([-math.sin(ang1), math.cos(ang1)])
+            else:
+                t0 = v1 / np.linalg.norm(v1)
 
-        if np.linalg.norm(v2) < 1e-9:
-            ang0_next = ang[(side_idx + 1) % 4][0]
-            t1 = np.array([-math.sin(ang0_next), math.cos(ang0_next)])
-        else:
-            t1 = (-v2) / np.linalg.norm(v2)
+            if np.linalg.norm(v2) < 1e-9:
+                ang0_next = ang[(side_idx + 1) % 4][0]
+                t1 = np.array([-math.sin(ang0_next), math.cos(ang0_next)])
+            else:
+                t1 = (-v2) / np.linalg.norm(v2)
 
-        p0 = c0 + self.R * np.array([t0[1], -t0[0]])
-        p3 = c1 + self.R * np.array([t1[1], -t1[0]])
-        return p0, p3
+            p0 = c0 + self.R * np.array([t0[1], -t0[0]])
+            p3 = c1c + self.R * np.array([t1[1], -t1[0]])
+            return p0, p3
+        else:
+            arcs = arc_geom_points(
+                self.a, self.b, self.R,
+                centers=self.arc_centers,
+                c1=False,
+            )
+            p0 = np.array(arcs[side_idx][2])
+            p3 = np.array(arcs[(side_idx + 1) % 4][1])
+            return p0, p3
 
     def bezier_ctrl_position(self, side_idx, seg_idx, ctrl_idx):
         p0, p3 = self._bezier_line_endpoints(side_idx)
@@ -217,6 +228,7 @@ class MainWindow(QMainWindow):
             n_line=self.bezier_points,
             centers=self.arc_centers,
             bezier_ctrl_offsets=self.bezier_ctrl_offsets,
+            c1=self.c1,
         )
 
     def arc_center_indices(self, contour):
@@ -224,6 +236,7 @@ class MainWindow(QMainWindow):
             self.a, self.b, self.R,
             centers=self.arc_centers,
             bezier_ctrl_offsets=self.bezier_ctrl_offsets,
+            c1=self.c1,
         )
         centers_geom = [arc[0] for arc in arcs]
         return [int(np.argmin(np.linalg.norm(contour - np.array(pt), axis=1))) for pt in centers_geom]
@@ -438,6 +451,7 @@ class MainWindow(QMainWindow):
             self.a, self.b, self.R,
             centers=self.arc_centers,
             bezier_ctrl_offsets=self.bezier_ctrl_offsets,
+            c1=self.c1,
         )
         arc_info = [
             (self.arc_centers[i][0], self.arc_centers[i][1], arcs[i][1], arcs[i][2])
@@ -541,6 +555,7 @@ class MainWindow(QMainWindow):
             self.R,
             centers=self.arc_centers,
             bezier_ctrl_offsets=self.bezier_ctrl_offsets,
+            c1=self.c1,
         )
 
     def area_error_percent(self):
@@ -564,6 +579,7 @@ class MainWindow(QMainWindow):
             self.a, self.b, self.R,
             centers=self.arc_centers,
             bezier_ctrl_offsets=self.bezier_ctrl_offsets,
+            c1=self.c1,
         )
         line_meta = []
         for i in range(4):

--- a/main_window.py
+++ b/main_window.py
@@ -21,6 +21,7 @@ class MainWindow(QMainWindow):
         self.line_width = 3
         self.step = 1.0
         self.bezier_points = 200
+        self.bezier_ctrl_count = 2  # control points per straight side
         self.scene = QGraphicsScene()
         self.view = QGraphicsView(self.scene)
         self.view.setRenderHint(QPainter.Antialiasing, True)
@@ -56,49 +57,61 @@ class MainWindow(QMainWindow):
     def compute_default_bezier_offsets(self):
         arcs = arc_geom_points(self.a, self.b, self.R, centers=self.arc_centers)
         self.bezier_ctrl_offsets = []
-        ang = _arc_angles_from_centers(self.arc_centers)
+        n = self.bezier_ctrl_count // 2
         for i in range(4):
             p0 = np.array(arcs[i][2])
             p3 = np.array(arcs[(i + 1) % 4][1])
+            if n == 0:
+                self.bezier_ctrl_offsets.append([])
+                continue
             chord = np.linalg.norm(p3 - p0)
-            d = chord / 3.0
-            ang1 = ang[i][1]
-            ang0_next = ang[(i + 1) % 4][0]
-            t0 = np.array([-math.sin(ang1), math.cos(ang1)])
-            t1 = np.array([-math.sin(ang0_next), math.cos(ang0_next)])
-            v1 = d * t0
-            v2 = -d * t1
-            self.bezier_ctrl_offsets.append([v1, v2])
+            dir_vec = (p3 - p0) / chord if chord > 1e-9 else np.array([1.0, 0.0])
+            seg_len = chord / n
+            v = (seg_len / 3.0) * dir_vec
+            offs = [[v, -v] for _ in range(n)]
+            self.bezier_ctrl_offsets.append(offs)
 
-    def _bezier_endpoints(self, seg_idx):
+    def change_bezier_ctrl_count(self, v):
+        self.bezier_ctrl_count = v
+        self.compute_default_bezier_offsets()
+        self.redraw_all(preserve_markers=True)
+
+    def _bezier_line_endpoints(self, side_idx):
         ang = _arc_angles_from_centers(self.arc_centers)
-        v1, v2 = [np.asarray(v, dtype=float) for v in self.bezier_ctrl_offsets[seg_idx]]
-        c0 = np.asarray(self.arc_centers[seg_idx], dtype=float)
-        c1 = np.asarray(self.arc_centers[(seg_idx + 1) % 4], dtype=float)
+        offs = self.bezier_ctrl_offsets[side_idx]
+        if offs:
+            v1 = np.asarray(offs[0][0], dtype=float)
+            v2 = np.asarray(offs[-1][1], dtype=float)
+        else:
+            v1 = np.zeros(2)
+            v2 = np.zeros(2)
+        c0 = np.asarray(self.arc_centers[side_idx], dtype=float)
+        c1 = np.asarray(self.arc_centers[(side_idx + 1) % 4], dtype=float)
 
         if np.linalg.norm(v1) < 1e-9:
-            ang1 = ang[seg_idx][1]
+            ang1 = ang[side_idx][1]
             t0 = np.array([-math.sin(ang1), math.cos(ang1)])
         else:
             t0 = v1 / np.linalg.norm(v1)
 
         if np.linalg.norm(v2) < 1e-9:
-            ang0_next = ang[(seg_idx + 1) % 4][0]
+            ang0_next = ang[(side_idx + 1) % 4][0]
             t1 = np.array([-math.sin(ang0_next), math.cos(ang0_next)])
         else:
             t1 = (-v2) / np.linalg.norm(v2)
 
         p0 = c0 + self.R * np.array([t0[1], -t0[0]])
         p3 = c1 + self.R * np.array([t1[1], -t1[0]])
-        return p0, p3, t0, t1
+        return p0, p3
 
-    def bezier_ctrl_position(self, seg_idx, ctrl_idx):
-        p0, p3, t0, t1 = self._bezier_endpoints(seg_idx)
-        v1, v2 = self.bezier_ctrl_offsets[seg_idx]
-        if ctrl_idx == 0:
-            return p0 + v1
-        else:
-            return p3 + v2
+    def bezier_ctrl_position(self, side_idx, seg_idx, ctrl_idx):
+        p0, p3 = self._bezier_line_endpoints(side_idx)
+        n = self.bezier_ctrl_count // 2
+        line_vec = p3 - p0
+        start = p0 + line_vec * (seg_idx / n)
+        end = p0 + line_vec * ((seg_idx + 1) / n)
+        v1, v2 = self.bezier_ctrl_offsets[side_idx][seg_idx]
+        return (start + v1) if ctrl_idx == 0 else (end + v2)
 
     def update_after_bezier_move(self):
         contour = self.get_contour()
@@ -106,10 +119,11 @@ class MainWindow(QMainWindow):
             grp.update_positions(contour)
         for fp in self.free_points:
             fp.update_position()
-        for pair in self.bezier_ctrl_points:
-            for cp in pair:
-                if not cp._syncing:
-                    cp.update_position()
+        for side in self.bezier_ctrl_points:
+            for pair in side:
+                for cp in pair:
+                    if not cp._syncing:
+                        cp.update_position()
         self._draw_background(contour)
         self._draw_contour(contour)
         self._draw_spline()
@@ -120,9 +134,10 @@ class MainWindow(QMainWindow):
             fp.update_radius()
         for cp in self.center_points:
             cp.update_radius()
-        for pair in self.bezier_ctrl_points:
-            for bp in pair:
-                bp.update_radius()
+        for side in self.bezier_ctrl_points:
+            for pair in side:
+                for bp in pair:
+                    bp.update_radius()
 
     def move_center(self, index, pos):
         """Update a circle center and redraw geometry immediately."""
@@ -225,9 +240,10 @@ class MainWindow(QMainWindow):
         for cp in self.center_points:
             if not cp._syncing:
                 cp.update_position()
-        for pair in self.bezier_ctrl_points:
-            for bp in pair:
-                bp.update_position()
+        for side in self.bezier_ctrl_points:
+            for pair in side:
+                for bp in pair:
+                    bp.update_position()
         self._draw_background(contour)
         self._draw_contour(contour)
         self._draw_spline()
@@ -323,14 +339,18 @@ class MainWindow(QMainWindow):
             self.center_points.append(cp)
 
         self.bezier_ctrl_points = []
+        n = self.bezier_ctrl_count // 2
         for i in range(4):
-            cp1 = BezierCtrlPoint(self, i, 0)
-            cp2 = BezierCtrlPoint(self, i, 1)
-            self.scene.addItem(cp1)
-            self.scene.addItem(cp2)
-            cp1.finish_init()
-            cp2.finish_init()
-            self.bezier_ctrl_points.append((cp1, cp2))
+            side_pts = []
+            for j in range(n):
+                cp1 = BezierCtrlPoint(self, i, j, 0)
+                cp2 = BezierCtrlPoint(self, i, j, 1)
+                self.scene.addItem(cp1)
+                self.scene.addItem(cp2)
+                cp1.finish_init()
+                cp2.finish_init()
+                side_pts.append((cp1, cp2))
+            self.bezier_ctrl_points.append(side_pts)
 
         self._prev_contour = contour.copy()
         self._draw_background(contour)

--- a/main_window.py
+++ b/main_window.py
@@ -20,6 +20,7 @@ class MainWindow(QMainWindow):
         self.point_radius = 7
         self.line_width = 3
         self.step = 1.0
+        self.bezier_points = 200
         self.scene = QGraphicsScene()
         self.view = QGraphicsView(self.scene)
         self.view.setRenderHint(QPainter.Antialiasing, True)
@@ -198,6 +199,7 @@ class MainWindow(QMainWindow):
             self.b,
             self.R,
             step=self.step,
+            n_line=self.bezier_points,
             centers=self.arc_centers,
             bezier_ctrl_offsets=self.bezier_ctrl_offsets,
         )

--- a/points.py
+++ b/points.py
@@ -162,3 +162,49 @@ class CenterPoint(QGraphicsEllipseItem):
             self.main_window.move_center(self.index, pos)
             return QPointF(*self.main_window.arc_centers[self.index])
         return super().itemChange(change, value)
+
+
+class BezierCtrlPoint(QGraphicsEllipseItem):
+    COLOR = QColor(200, 200, 0)
+
+    def __init__(self, main_window, seg_idx, ctrl_idx):
+        self.main_window = main_window
+        self.seg_idx = seg_idx
+        self.ctrl_idx = ctrl_idx
+        radius = main_window.point_radius
+        super().__init__(-radius, -radius, 2 * radius, 2 * radius)
+        self.setBrush(QBrush(self.COLOR))
+        self.setPen(QPen(Qt.black, 1))
+        self.setZValue(7)
+        self._syncing = True
+        self.setFlag(QGraphicsEllipseItem.ItemIsMovable, True)
+        self.setFlag(QGraphicsEllipseItem.ItemSendsScenePositionChanges, True)
+        self.update_position()
+
+    def finish_init(self):
+        self._syncing = False
+
+    def update_position(self):
+        pos = self.main_window.bezier_ctrl_position(self.seg_idx, self.ctrl_idx)
+        self._syncing = True
+        self.setPos(*pos)
+        self._syncing = False
+
+    def update_radius(self):
+        r = self.main_window.point_radius
+        self.setRect(-r, -r, 2 * r, 2 * r)
+
+    def itemChange(self, change, value):
+        if change == QGraphicsEllipseItem.ItemPositionChange:
+            if self._syncing:
+                return value
+            p0, p3, t0, t1 = self.main_window._bezier_endpoints(self.seg_idx)
+            base = p0 if self.ctrl_idx == 0 else p3
+            tan = t0 if self.ctrl_idx == 0 else -t1
+            vec = np.array([value.x(), value.y()]) - base
+            length = float(np.dot(vec, tan))
+            self.main_window.bezier_ctrl_lens[self.seg_idx][self.ctrl_idx] = length
+            new_pos = base + length * tan
+            self.main_window.update_after_bezier_move()
+            return QPointF(*new_pos)
+        return super().itemChange(change, value)

--- a/points.py
+++ b/points.py
@@ -167,8 +167,9 @@ class CenterPoint(QGraphicsEllipseItem):
 class BezierCtrlPoint(QGraphicsEllipseItem):
     COLOR = QColor(200, 200, 0)
 
-    def __init__(self, main_window, seg_idx, ctrl_idx):
+    def __init__(self, main_window, side_idx, seg_idx, ctrl_idx):
         self.main_window = main_window
+        self.side_idx = side_idx
         self.seg_idx = seg_idx
         self.ctrl_idx = ctrl_idx
         radius = main_window.point_radius
@@ -185,7 +186,9 @@ class BezierCtrlPoint(QGraphicsEllipseItem):
         self._syncing = False
 
     def update_position(self):
-        pos = self.main_window.bezier_ctrl_position(self.seg_idx, self.ctrl_idx)
+        pos = self.main_window.bezier_ctrl_position(
+            self.side_idx, self.seg_idx, self.ctrl_idx
+        )
         self._syncing = True
         self.setPos(*pos)
         self._syncing = False
@@ -198,10 +201,14 @@ class BezierCtrlPoint(QGraphicsEllipseItem):
         if change == QGraphicsEllipseItem.ItemPositionChange:
             if self._syncing:
                 return value
-            p0, p3, _, _ = self.main_window._bezier_endpoints(self.seg_idx)
-            base = p0 if self.ctrl_idx == 0 else p3
+            p0, p3 = self.main_window._bezier_line_endpoints(self.side_idx)
+            n = self.main_window.bezier_ctrl_count // 2
+            line_vec = p3 - p0
+            start = p0 + line_vec * (self.seg_idx / n)
+            end = p0 + line_vec * ((self.seg_idx + 1) / n)
+            base = start if self.ctrl_idx == 0 else end
             vec = np.array([value.x(), value.y()]) - base
-            self.main_window.bezier_ctrl_offsets[self.seg_idx][self.ctrl_idx] = vec
+            self.main_window.bezier_ctrl_offsets[self.side_idx][self.seg_idx][self.ctrl_idx] = vec
             self.main_window.update_after_bezier_move()
             return value
         return super().itemChange(change, value)

--- a/points.py
+++ b/points.py
@@ -198,13 +198,10 @@ class BezierCtrlPoint(QGraphicsEllipseItem):
         if change == QGraphicsEllipseItem.ItemPositionChange:
             if self._syncing:
                 return value
-            p0, p3, t0, t1 = self.main_window._bezier_endpoints(self.seg_idx)
+            p0, p3, _, _ = self.main_window._bezier_endpoints(self.seg_idx)
             base = p0 if self.ctrl_idx == 0 else p3
-            tan = t0 if self.ctrl_idx == 0 else -t1
             vec = np.array([value.x(), value.y()]) - base
-            length = float(np.dot(vec, tan))
-            self.main_window.bezier_ctrl_lens[self.seg_idx][self.ctrl_idx] = length
-            new_pos = base + length * tan
+            self.main_window.bezier_ctrl_offsets[self.seg_idx][self.ctrl_idx] = vec
             self.main_window.update_after_bezier_move()
-            return QPointF(*new_pos)
+            return value
         return super().itemChange(change, value)

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -96,3 +96,23 @@ def test_area_changes_with_moved_centers():
     centers[0] = (centers[0][0] - 30, centers[0][1] + 15)
     changed = rounded_rect_area(a, b, R, centers=centers)
     assert not np.isclose(changed, default_area)
+
+
+def test_area_matches_sampling_with_bezier_segments():
+    a, b, R = 200, 100, 20
+    centers = default_centers(a, b, R)
+    offsets = [
+        [(30, 0), (30, 0)],
+        [(0, 0), (0, 0)],
+        [(0, 0), (0, 0)],
+        [(0, 0), (0, 0)],
+    ]
+    exact = rounded_rect_area(a, b, R, centers=centers, bezier_ctrl_offsets=offsets)
+    pts = rounded_rect_points(
+        a, b, R, step=0.2, centers=centers, bezier_ctrl_offsets=offsets
+    )
+    x, y = pts[:, 0], pts[:, 1]
+    sample = 0.5 * abs(np.dot(x, np.roll(y, -1)) - np.dot(y, np.roll(x, -1)))
+    assert np.isclose(exact, sample, rtol=1e-2)
+    default_area = rounded_rect_area(a, b, R, centers=centers)
+    assert not np.isclose(exact, default_area)

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -102,10 +102,10 @@ def test_area_matches_sampling_with_bezier_segments():
     a, b, R = 200, 100, 20
     centers = default_centers(a, b, R)
     offsets = [
-        [(30, 0), (30, 0)],
-        [(0, 0), (0, 0)],
-        [(0, 0), (0, 0)],
-        [(0, 0), (0, 0)],
+        [[(30, 0), (30, 0)]],
+        [],
+        [],
+        [],
     ]
     exact = rounded_rect_area(a, b, R, centers=centers, bezier_ctrl_offsets=offsets)
     pts = rounded_rect_points(
@@ -116,3 +116,17 @@ def test_area_matches_sampling_with_bezier_segments():
     assert np.isclose(exact, sample, rtol=1e-2)
     default_area = rounded_rect_area(a, b, R, centers=centers)
     assert not np.isclose(exact, default_area)
+
+
+def test_multiple_control_points_match_straight_area():
+    a, b, R = 200, 100, 20
+    centers = default_centers(a, b, R)
+    offsets = [
+        [[(0, 0), (0, 0)], [(0, 0), (0, 0)]],
+        [],
+        [],
+        [],
+    ]
+    area_multi = rounded_rect_area(a, b, R, centers=centers, bezier_ctrl_offsets=offsets)
+    area_default = rounded_rect_area(a, b, R, centers=centers)
+    assert np.isclose(area_multi, area_default)

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -130,3 +130,39 @@ def test_multiple_control_points_match_straight_area():
     area_multi = rounded_rect_area(a, b, R, centers=centers, bezier_ctrl_offsets=offsets)
     area_default = rounded_rect_area(a, b, R, centers=centers)
     assert np.isclose(area_multi, area_default)
+
+
+def test_c0_continuity_and_area():
+    a, b, R = 200, 100, 20
+    centers = default_centers(a, b, R)
+    offsets = [
+        [[(30, 0), (30, 0)]],
+        [],
+        [],
+        [],
+    ]
+    arcs_default = arc_geom_points(a, b, R, centers=centers)
+    arcs_c0 = arc_geom_points(
+        a, b, R, centers=centers, bezier_ctrl_offsets=offsets, c1=False
+    )
+    arcs_c1 = arc_geom_points(
+        a, b, R, centers=centers, bezier_ctrl_offsets=offsets, c1=True
+    )
+    for ad, ac0 in zip(arcs_default, arcs_c0):
+        assert np.allclose(ad[1], ac0[1])
+        assert np.allclose(ad[2], ac0[2])
+    assert not np.allclose(arcs_c1[0][2], arcs_default[0][2])
+
+    exact = rounded_rect_area(
+        a, b, R, centers=centers, bezier_ctrl_offsets=offsets, c1=False
+    )
+    pts = rounded_rect_points(
+        a, b, R, step=0.2, centers=centers, bezier_ctrl_offsets=offsets, c1=False
+    )
+    x, y = pts[:, 0], pts[:, 1]
+    sample = 0.5 * abs(np.dot(x, np.roll(y, -1)) - np.dot(y, np.roll(x, -1)))
+    assert np.isclose(exact, sample, rtol=1e-2)
+    c1_area = rounded_rect_area(
+        a, b, R, centers=centers, bezier_ctrl_offsets=offsets, c1=True
+    )
+    assert not np.isclose(exact, c1_area)


### PR DESCRIPTION
## Summary
- replace straight segments with cubic Bezier equivalents controlled by draggable handles
- track Bezier control lengths and update contour calculations
- provide graphics items for Bezier control points

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c406e2a7f4832794287756e023432d